### PR TITLE
feat: use optimized snapshots provided by testplane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 build
 testplane-mcp-*.tgz
+tmp
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.11.2",
         "@testing-library/webdriverio": "^3.2.1",
         "commander": "^13.1.0",
-        "testplane": "latest",
+        "testplane": "^8.29.3",
         "zod": "^3.22.4"
       },
       "bin": {
@@ -2951,12 +2951,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -9374,9 +9368,9 @@
       }
     },
     "node_modules/testplane": {
-      "version": "8.29.2",
-      "resolved": "https://registry.npmjs.org/testplane/-/testplane-8.29.2.tgz",
-      "integrity": "sha512-kowQTF6+DYJD9VzTUJt68CGW2PW9xXn/5VA7COM+DgxvWB9XlLu3lyaKjIFLSf2CXZr8yq0xg7OeBHxcOj8FIw==",
+      "version": "8.29.3",
+      "resolved": "https://registry.npmjs.org/testplane/-/testplane-8.29.3.tgz",
+      "integrity": "sha512-sW6BGRYV9/k5D0zl6g4tRYJLqBoVdOnEzDcBpmv0uPR4OUY0/3bzmWpgbeDUW7D2y7wpBm33vqqIDLnLQaltBw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.24.2",
@@ -9389,7 +9383,6 @@
         "@testplane/wdio-utils": "9.5.3",
         "@testplane/webdriverio": "9.5.20",
         "@vitest/spy": "2.1.4",
-        "bluebird": "3.5.1",
         "chalk": "2.4.2",
         "clear-require": "1.0.1",
         "cli-progress": "3.12.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@modelcontextprotocol/sdk": "^1.11.2",
     "@testing-library/webdriverio": "^3.2.1",
     "commander": "^13.1.0",
-    "testplane": "latest",
+    "testplane": "^8.29.3",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/tools/click-on-element.ts
+++ b/src/tools/click-on-element.ts
@@ -1,7 +1,7 @@
 import { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolDefinition } from "../types.js";
 import { contextProvider } from "../context-provider.js";
-import { createBrowserStateResponse, createErrorResponse } from "../responses/index.js";
+import { createElementStateResponse, createErrorResponse } from "../responses/index.js";
 import { elementSelectorSchema, findElement } from "./utils/element-selector.js";
 
 export const elementClickSchema = elementSelectorSchema;
@@ -17,21 +17,21 @@ const clickOnElementCb: ToolCallback<typeof elementClickSchema> = async args => 
 
         console.error(`Successfully clicked element with ${queryDescription}`);
 
-        return await createBrowserStateResponse(browser, {
+        return await createElementStateResponse(element, {
             action: `Successfully clicked element found by ${queryDescription}`,
             testplaneCode,
             additionalInfo: `Element selection strategy: ${args.queryType ? `Semantic query (${args.queryType})` : "CSS selector (fallback)"}`,
         });
     } catch (error) {
         console.error("Error clicking element:", error);
-        let errorMessage = "Error clicking element";
 
         if (error instanceof Error && error.message.includes("Unable to find")) {
-            errorMessage =
-                "Element not found. Try using a different query strategy or check if the element exists on the page.";
+            return createErrorResponse(
+                "Element not found. Try using a different query strategy or check if the element exists on the page.",
+            );
         }
 
-        return createErrorResponse(errorMessage, error instanceof Error ? error : undefined);
+        return createErrorResponse("Error clicking element", error instanceof Error ? error : undefined);
     }
 };
 

--- a/src/tools/type-into-element.ts
+++ b/src/tools/type-into-element.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolDefinition } from "../types.js";
 import { contextProvider } from "../context-provider.js";
-import { createBrowserStateResponse, createErrorResponse } from "../responses/index.js";
+import { createElementStateResponse, createErrorResponse } from "../responses/index.js";
 import { elementSelectorSchema, findElement } from "./utils/element-selector.js";
 
 export const typeIntoElementSchema = {
@@ -27,21 +27,21 @@ const typeIntoElementCb: ToolCallback<typeof typeIntoElementSchema> = async args
 
         console.error(`Successfully typed "${text}" into element with ${queryDescription}`);
 
-        return await createBrowserStateResponse(browser, {
+        return await createElementStateResponse(element, {
             action: `Successfully typed "${text}" into element found by ${queryDescription}`,
             testplaneCode,
             additionalInfo: `Element selection strategy: ${selectorArgs.queryType ? `Semantic query (${selectorArgs.queryType})` : "CSS selector (fallback)"}`,
         });
     } catch (error) {
         console.error("Error typing into element:", error);
-        let errorMessage = "Error typing into element";
 
         if (error instanceof Error && error.message.includes("Unable to find")) {
-            errorMessage =
-                "Element not found. Try using a different query strategy or check if the element exists on the page.";
+            return createErrorResponse(
+                "Element not found. Try using a different query strategy or check if the element exists on the page.",
+            );
         }
 
-        return createErrorResponse(errorMessage, error instanceof Error ? error : undefined);
+        return createErrorResponse("Error typing into element", error instanceof Error ? error : undefined);
     }
 };
 

--- a/test/responses/index.test.ts
+++ b/test/responses/index.test.ts
@@ -133,9 +133,7 @@ describe("responses/index", () => {
             const responseText = result.content[0].text;
 
             expect(responseText).toContain("## Current Tab Snapshot");
-            expect(responseText).toContain("```html");
             expect(responseText).toContain("<html><body>Test content</body></html>");
-            expect(responseText).toContain("```");
         });
 
         it("should include additional information when provided", async () => {

--- a/test/tools/click-on-element.test.ts
+++ b/test/tools/click-on-element.test.ts
@@ -57,7 +57,7 @@ describe(
                 expect(result.isError).toBe(false);
                 const content = result.content as Array<{ type: string; text: string }>;
                 expect(content[0].text).toContain("Successfully clicked element");
-                expect(content[0].text).toContain("clicked-indicator show");
+                expect(content[0].text).toContain("span.clicked-indicator.show");
             });
 
             it("should click an element using CSS selector", async () => {
@@ -71,7 +71,7 @@ describe(
                 expect(result.isError).toBe(false);
                 const content = result.content as Array<{ type: string; text: string }>;
                 expect(content[0].text).toContain("Successfully clicked element");
-                expect(content[0].text).toContain("clicked-indicator show");
+                expect(content[0].text).toContain("span.clicked-indicator.show");
             });
 
             it("should return correct testplane code for clicked element", async () => {


### PR DESCRIPTION
### What's done?

After implementing `unstable_captureDomSnapshot` command in testplane, it became possible to significantly reduce snapshot sizes and therefore API tokens usage & IDE performance. This PR integrates this change into MCP server.
