### PR TITLE
feat: add the timeout option to navigate command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -794,9 +794,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -829,12 +829,12 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -921,6 +921,18 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1270,28 +1282,6 @@
         "win32"
       ]
     },
-    "node_modules/@rrweb/record": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/record/-/record-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-WbzcybTEqT+cKkOnzYiyaAYvNzAIxTK9f8qNLNOG9lOqWsmi+qu/W7CEdxHmfjlfgXGw/f7bxGZggAWVaizKqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@rrweb/types": "^2.0.0-alpha.18",
-        "rrweb": "^2.0.0-alpha.18"
-      }
-    },
-    "node_modules/@rrweb/types": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-iMH3amHthJZ9x3gGmBPmdfim7wLGygC2GciIkw2A6SO8giSn8PHYtRT8OKNH4V+k3SZ6RSnYHcTQxBA7pSWZ3Q==",
-      "license": "MIT"
-    },
-    "node_modules/@rrweb/utils": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-qV8azQYo9RuwW4NGRtOiQfTBdHNL1B0Q//uRLMbCSjbaKqJYd88Js17Bdskj65a0Vgp2dwTLPIZ0gK47dfjfaA==",
-      "license": "MIT"
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -1302,6 +1292,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
       "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -1319,6 +1310,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
       "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+      "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.1"
       },
@@ -1331,15 +1323,16 @@
       "link": true
     },
     "node_modules/@testplane/devtools": {
-      "version": "8.32.3",
-      "resolved": "https://registry.npmjs.org/@testplane/devtools/-/devtools-8.32.3.tgz",
-      "integrity": "sha512-QWSIhYw/Di91Imu61Z82uJYTwqM8IiEuD8ynZvgrknWruJwBOStp4H4W0WWQLnZjFph9MjSJVK+3zuXp27Xc7A==",
+      "version": "8.32.5",
+      "resolved": "https://registry.npmjs.org/@testplane/devtools/-/devtools-8.32.5.tgz",
+      "integrity": "sha512-VpQIUDMgBB65iao2WgeuoqEPdiwek9bJEVTLtWZikxfDabkPEVwODelJmgh6Yy5lvEIDsHinsJVGvJhg2y+5fg==",
+      "license": "MIT",
       "dependencies": {
-        "@testplane/wdio-config": "9.5.3",
-        "@testplane/wdio-logger": "9.4.6",
-        "@testplane/wdio-protocols": "9.4.6",
-        "@testplane/wdio-types": "9.5.2",
-        "@testplane/wdio-utils": "9.5.3",
+        "@testplane/wdio-config": "9.5.4",
+        "@testplane/wdio-logger": "9.4.7",
+        "@testplane/wdio-protocols": "9.4.7",
+        "@testplane/wdio-types": "9.5.4",
+        "@testplane/wdio-utils": "9.5.4",
         "@types/node": "^20.1.0",
         "chrome-launcher": "^1.0.0",
         "edge-paths": "^3.0.5",
@@ -1355,17 +1348,19 @@
       }
     },
     "node_modules/@testplane/devtools/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@testplane/devtools/node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
       "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -1381,6 +1376,7 @@
       "resolved": "https://registry.npmjs.org/@testplane/edgedriver/-/edgedriver-6.1.4.tgz",
       "integrity": "sha512-4koRBT84dzso/231E3X4KIH7aC7DVTVf1R8XltahPBQDOUMOgwa6WCRztu9jHkALmsUn8BjBVnF8a3hmK4IfzQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@testplane/wdio-logger": "^9.4.4",
         "@zip.js/zip.js": "^2.7.53",
@@ -1400,17 +1396,19 @@
       }
     },
     "node_modules/@testplane/edgedriver/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@testplane/edgedriver/node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
       "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -1426,6 +1424,7 @@
       "resolved": "https://registry.npmjs.org/@testplane/geckodriver/-/geckodriver-5.0.2.tgz",
       "integrity": "sha512-ax6E0jkCa/N3sMXXOQcA6wu+v8B5wtDGwJe9Y7e2TByt7z/srOKh7iTuNfzeIgW9pKubenkivIKG29DMiFC/2w==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@testplane/wdio-logger": "^9.4.4",
         "@zip.js/zip.js": "^2.7.54",
@@ -1523,9 +1522,146 @@
       "link": true
     },
     "node_modules/@testplane/wdio-config": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-config/-/wdio-config-9.5.4.tgz",
+      "integrity": "sha512-GXZ/uSmTTFMTbmfhg6X34sSSzkxh+vx3mF/XPFoWshmEg5n/rIXwbbL5FOKoggrEmdgQJZ/0hTjxZJMlHyf5Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@testplane/wdio-logger": "9.4.7",
+        "@testplane/wdio-types": "9.5.4",
+        "@testplane/wdio-utils": "9.5.4",
+        "deepmerge-ts": "^7.0.3",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/wdio-logger": {
+      "version": "9.4.7",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-logger/-/wdio-logger-9.4.7.tgz",
+      "integrity": "sha512-O7wuGM1S3BmptkyaFgozMPWaLJP9d3TGXH0ZwVAOji6UO02ROBSYCvFvt5yPWC93mN4/ocpApF0Oj0gv9dkaiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/wdio-protocols": {
+      "version": "9.4.7",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-protocols/-/wdio-protocols-9.4.7.tgz",
+      "integrity": "sha512-SQb69YKa/G5062GUrBb04OpY6BgyXOdNzacwcnZ/HMJ1jVRlImvcAU0eBZGdiJQIk9H+HotaUgdDpWrl/2b0Cg==",
+      "license": "MIT"
+    },
+    "node_modules/@testplane/wdio-repl": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-repl/-/wdio-repl-9.4.4.tgz",
+      "integrity": "sha512-h0+yQ9iV7U55pt4RDFKH7DnJ8J1SnPbZ/UgCz/oZ0u7N6HG2EN6tGldwZUZjQadwVE38BgQk6l+BwVHuLqEIZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/wdio-types": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.4.tgz",
+      "integrity": "sha512-r6M7+T9lSEAiuM79XN3tc1/ARMayEINmvjjgroRgOKGv9Eks3KlzqJIjqhhHZcms9MtTueYvhrL/qUcAn4t9rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/wdio-utils": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-utils/-/wdio-utils-9.5.4.tgz",
+      "integrity": "sha512-I9KgSi/Qc5VW94v3RJZfK0TyuUPb1ywETb1Dw8IlJbk1t5EJb0dFfTWoJX53LgaofXxmjaHBodO3KfMQTue3Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@puppeteer/browsers": "^2.2.0",
+        "@testplane/edgedriver": "^6.1.4",
+        "@testplane/geckodriver": "^5.0.2",
+        "@testplane/wdio-logger": "9.4.6",
+        "@testplane/wdio-types": "9.5.4",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^7.0.3",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.2.24",
+        "safaridriver": "^1.0.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/wdio-utils/node_modules/@testplane/wdio-logger": {
+      "version": "9.4.6",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-logger/-/wdio-logger-9.4.6.tgz",
+      "integrity": "sha512-ZtOnihuxOWxNpIrctRKrtmI7hapR8xCBie5fmo8ojNhiDG5+vouXbhTfYGIdRMJTfH0Fpmz3tVRHJcSjBOwkzg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/wdio-utils/node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@testplane/webdriver": {
+      "version": "9.5.17",
+      "resolved": "https://registry.npmjs.org/@testplane/webdriver/-/webdriver-9.5.17.tgz",
+      "integrity": "sha512-ecmgc4MuLVv+XH49tGDq59TMzSzFkB5yOMOKv5xXDEMKqLwuEssWd1UmHuWYsJwTvIjbDHXto2lvfGrDRKaoPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@testplane/wdio-config": "9.5.3",
+        "@testplane/wdio-logger": "9.4.6",
+        "@testplane/wdio-protocols": "9.4.6",
+        "@testplane/wdio-types": "9.5.5",
+        "@testplane/wdio-utils": "9.5.3",
+        "@types/node": "^20.1.0",
+        "@types/ws": "^8.5.3",
+        "deepmerge-ts": "^7.0.3",
+        "got": "12.6.1",
+        "ky": "0.33.0",
+        "undici": "6.12.0",
+        "ws": "^8.8.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/webdriver/node_modules/@testplane/wdio-config": {
       "version": "9.5.3",
       "resolved": "https://registry.npmjs.org/@testplane/wdio-config/-/wdio-config-9.5.3.tgz",
       "integrity": "sha512-329lufaem6vxLq5Govv9lRzue1o2571HsFhI5TpiSH3C1x3SxQ2kQokCN2nGMS4IIEbSPjRQDuKNUuSWhS4hVA==",
+      "license": "MIT",
       "dependencies": {
         "@testplane/wdio-logger": "9.4.6",
         "@testplane/wdio-types": "9.5.2",
@@ -1538,10 +1674,23 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@testplane/wdio-logger": {
+    "node_modules/@testplane/webdriver/node_modules/@testplane/wdio-config/node_modules/@testplane/wdio-types": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.2.tgz",
+      "integrity": "sha512-D7ge7qJmcR2CG39YBlZ8lZRSeM/yOeBmQXsFxE0LlKurG3h+pEVWiuLhFW6ow2lZvR2jR2tHXI16IRvpXz3BKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/webdriver/node_modules/@testplane/wdio-logger": {
       "version": "9.4.6",
       "resolved": "https://registry.npmjs.org/@testplane/wdio-logger/-/wdio-logger-9.4.6.tgz",
       "integrity": "sha512-ZtOnihuxOWxNpIrctRKrtmI7hapR8xCBie5fmo8ojNhiDG5+vouXbhTfYGIdRMJTfH0Fpmz3tVRHJcSjBOwkzg==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "loglevel": "^1.6.0",
@@ -1552,15 +1701,17 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@testplane/wdio-protocols": {
+    "node_modules/@testplane/webdriver/node_modules/@testplane/wdio-protocols": {
       "version": "9.4.6",
       "resolved": "https://registry.npmjs.org/@testplane/wdio-protocols/-/wdio-protocols-9.4.6.tgz",
-      "integrity": "sha512-r++AmapEhXpShtNsYbqhX71iZSyUp7YyZV+RoamWVyvgP3ljpeU9cLksz2imyZJ5fCas1qcx9xElPKHRF/zcxw=="
+      "integrity": "sha512-r++AmapEhXpShtNsYbqhX71iZSyUp7YyZV+RoamWVyvgP3ljpeU9cLksz2imyZJ5fCas1qcx9xElPKHRF/zcxw==",
+      "license": "MIT"
     },
-    "node_modules/@testplane/wdio-repl": {
-      "version": "9.4.4",
-      "resolved": "https://registry.npmjs.org/@testplane/wdio-repl/-/wdio-repl-9.4.4.tgz",
-      "integrity": "sha512-h0+yQ9iV7U55pt4RDFKH7DnJ8J1SnPbZ/UgCz/oZ0u7N6HG2EN6tGldwZUZjQadwVE38BgQk6l+BwVHuLqEIZA==",
+    "node_modules/@testplane/webdriver/node_modules/@testplane/wdio-types": {
+      "version": "9.5.5",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.5.tgz",
+      "integrity": "sha512-g1vFPN8lfojGHWqQhSMSIfjdL/qiPgk3FGjmvSpTjnkbsNKxoVgRz7O6TeBXBy0h+hEIfXAjWX0utwz2eHjK4Q==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -1568,21 +1719,11 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@testplane/wdio-types": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.2.tgz",
-      "integrity": "sha512-D7ge7qJmcR2CG39YBlZ8lZRSeM/yOeBmQXsFxE0LlKurG3h+pEVWiuLhFW6ow2lZvR2jR2tHXI16IRvpXz3BKQ==",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@testplane/wdio-utils": {
+    "node_modules/@testplane/webdriver/node_modules/@testplane/wdio-utils": {
       "version": "9.5.3",
       "resolved": "https://registry.npmjs.org/@testplane/wdio-utils/-/wdio-utils-9.5.3.tgz",
       "integrity": "sha512-xZQqXn3ga1aY1JTTnF137lT6Evmn7Dtxs6TSlSEAG3dY+eLIZNz7n0tLNG49BYZY3l8F2k+0TdU6SZ0p28L7qA==",
+      "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
         "@testplane/edgedriver": "^6.1.4",
@@ -1602,43 +1743,11 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@testplane/wdio-utils/node_modules/get-port": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@testplane/webdriver": {
-      "version": "9.5.12",
-      "resolved": "https://registry.npmjs.org/@testplane/webdriver/-/webdriver-9.5.12.tgz",
-      "integrity": "sha512-uZTSO8HW2kFH5MGUVWeLY86e95zj3ZX05tYlA31J5sgij7q71TDRMjGJ7xjjjfMoA2U9dFg6ZlrI/WBwkMSEeg==",
-      "dependencies": {
-        "@testplane/wdio-config": "9.5.3",
-        "@testplane/wdio-logger": "9.4.6",
-        "@testplane/wdio-protocols": "9.4.6",
-        "@testplane/wdio-types": "9.5.3",
-        "@testplane/wdio-utils": "9.5.3",
-        "@types/node": "^20.1.0",
-        "@types/ws": "^8.5.3",
-        "deepmerge-ts": "^7.0.3",
-        "got": "12.6.1",
-        "ky": "0.33.0",
-        "undici": "6.12.0",
-        "ws": "^8.8.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@testplane/webdriver/node_modules/@testplane/wdio-types": {
-      "version": "9.5.3",
-      "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.3.tgz",
-      "integrity": "sha512-rubeNOnw0eozqnAoVl6oWEipV8ZeAPCv3UDRyZk/mdu7IBZUPuyJUX3cbiWnj9KCiJeVy3Qy6Ohn7Apod/zzog==",
+    "node_modules/@testplane/webdriver/node_modules/@testplane/wdio-utils/node_modules/@testplane/wdio-types": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.2.tgz",
+      "integrity": "sha512-D7ge7qJmcR2CG39YBlZ8lZRSeM/yOeBmQXsFxE0LlKurG3h+pEVWiuLhFW6ow2lZvR2jR2tHXI16IRvpXz3BKQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -1646,18 +1755,31 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@testplane/webdriver/node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@testplane/webdriverio": {
-      "version": "9.5.21",
-      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.21.tgz",
-      "integrity": "sha512-KjaFlG+tR67+HIEvMVf1Tf0JhQIEJYB2P7k0Rj/i7LsPJ99Ielvhlf6/WDI2mMUCJBuWV3FJzUdJoZmx21PhMw==",
+      "version": "9.5.28",
+      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.28.tgz",
+      "integrity": "sha512-UWkAOFhhL5DYquwDsr0JnjD5TMC0/drlrUJFWHz6t+s9y8el5z0B+5WJX6xsrjn3q4HyqMCpALNTFZLJCNqj0Q==",
+      "license": "MIT",
       "dependencies": {
         "@testplane/wdio-config": "9.5.3",
         "@testplane/wdio-logger": "9.4.6",
         "@testplane/wdio-protocols": "9.4.6",
         "@testplane/wdio-repl": "9.4.4",
-        "@testplane/wdio-types": "9.5.3",
+        "@testplane/wdio-types": "9.5.5",
         "@testplane/wdio-utils": "9.5.3",
-        "@testplane/webdriver": "9.5.12",
+        "@testplane/webdriver": "9.5.17",
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
         "archiver": "^7.0.1",
@@ -1691,10 +1813,97 @@
         }
       }
     },
-    "node_modules/@testplane/webdriverio/node_modules/@testplane/wdio-types": {
+    "node_modules/@testplane/webdriverio/node_modules/@testplane/wdio-config": {
       "version": "9.5.3",
-      "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.3.tgz",
-      "integrity": "sha512-rubeNOnw0eozqnAoVl6oWEipV8ZeAPCv3UDRyZk/mdu7IBZUPuyJUX3cbiWnj9KCiJeVy3Qy6Ohn7Apod/zzog==",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-config/-/wdio-config-9.5.3.tgz",
+      "integrity": "sha512-329lufaem6vxLq5Govv9lRzue1o2571HsFhI5TpiSH3C1x3SxQ2kQokCN2nGMS4IIEbSPjRQDuKNUuSWhS4hVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@testplane/wdio-logger": "9.4.6",
+        "@testplane/wdio-types": "9.5.2",
+        "@testplane/wdio-utils": "9.5.3",
+        "deepmerge-ts": "^7.0.3",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/webdriverio/node_modules/@testplane/wdio-config/node_modules/@testplane/wdio-types": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.2.tgz",
+      "integrity": "sha512-D7ge7qJmcR2CG39YBlZ8lZRSeM/yOeBmQXsFxE0LlKurG3h+pEVWiuLhFW6ow2lZvR2jR2tHXI16IRvpXz3BKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/webdriverio/node_modules/@testplane/wdio-logger": {
+      "version": "9.4.6",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-logger/-/wdio-logger-9.4.6.tgz",
+      "integrity": "sha512-ZtOnihuxOWxNpIrctRKrtmI7hapR8xCBie5fmo8ojNhiDG5+vouXbhTfYGIdRMJTfH0Fpmz3tVRHJcSjBOwkzg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/webdriverio/node_modules/@testplane/wdio-protocols": {
+      "version": "9.4.6",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-protocols/-/wdio-protocols-9.4.6.tgz",
+      "integrity": "sha512-r++AmapEhXpShtNsYbqhX71iZSyUp7YyZV+RoamWVyvgP3ljpeU9cLksz2imyZJ5fCas1qcx9xElPKHRF/zcxw==",
+      "license": "MIT"
+    },
+    "node_modules/@testplane/webdriverio/node_modules/@testplane/wdio-types": {
+      "version": "9.5.5",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.5.tgz",
+      "integrity": "sha512-g1vFPN8lfojGHWqQhSMSIfjdL/qiPgk3FGjmvSpTjnkbsNKxoVgRz7O6TeBXBy0h+hEIfXAjWX0utwz2eHjK4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/webdriverio/node_modules/@testplane/wdio-utils": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-utils/-/wdio-utils-9.5.3.tgz",
+      "integrity": "sha512-xZQqXn3ga1aY1JTTnF137lT6Evmn7Dtxs6TSlSEAG3dY+eLIZNz7n0tLNG49BYZY3l8F2k+0TdU6SZ0p28L7qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@puppeteer/browsers": "^2.2.0",
+        "@testplane/edgedriver": "^6.1.4",
+        "@testplane/geckodriver": "^5.0.2",
+        "@testplane/wdio-logger": "9.4.6",
+        "@testplane/wdio-types": "9.5.2",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^7.0.3",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.2.24",
+        "safaridriver": "^1.0.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@testplane/webdriverio/node_modules/@testplane/wdio-utils/node_modules/@testplane/wdio-types": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.2.tgz",
+      "integrity": "sha512-D7ge7qJmcR2CG39YBlZ8lZRSeM/yOeBmQXsFxE0LlKurG3h+pEVWiuLhFW6ow2lZvR2jR2tHXI16IRvpXz3BKQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -1703,17 +1912,31 @@
       }
     },
     "node_modules/@testplane/webdriverio/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@testplane/webdriverio/node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@testplane/webdriverio/node_modules/minimatch": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
       "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -1750,12 +1973,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/css-font-loading-module": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
-      "license": "MIT"
-    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1773,9 +1990,10 @@
       "license": "MIT"
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -2276,12 +2494,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/@xstate/fsm": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
-      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
-      "license": "MIT"
-    },
     "node_modules/@zip.js/zip.js": {
       "version": "2.7.62",
       "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.62.tgz",
@@ -2574,15 +2786,6 @@
         }
       }
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2613,9 +2816,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -2736,6 +2939,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
       "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       }
@@ -2744,6 +2948,7 @@
       "version": "10.2.14",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
       "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.2",
         "get-stream": "^6.0.1",
@@ -2761,6 +2966,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -2921,9 +3127,10 @@
       }
     },
     "node_modules/chrome-launcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.0.tgz",
-      "integrity": "sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+      "integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "*",
         "escape-string-regexp": "^4.0.0",
@@ -3262,6 +3469,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -3276,6 +3484,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3312,6 +3521,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -3830,16 +4040,6 @@
         "source-map": "~0.6.1"
       }
     },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/eslint": {
       "version": "9.27.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
@@ -4244,18 +4444,39 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4265,6 +4486,7 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
       "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4410,6 +4632,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
       "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14.17"
       }
@@ -4445,14 +4668,17 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -4586,9 +4812,9 @@
       }
     },
     "node_modules/gemini-configparser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/gemini-configparser/-/gemini-configparser-1.4.1.tgz",
-      "integrity": "sha512-vfaj/nMgyHrcruEyk9BApLLqWusuQbdH0+awSTCrpTMam1XoM1NDYJEz/iEW7NZjUEl+Bh/tYM9lLPlvwCi1kA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/gemini-configparser/-/gemini-configparser-1.4.2.tgz",
+      "integrity": "sha512-UgCSMUdWpordb1UgbUuJCMCv8fqdkOhu23k8QyaTdUzp4urREwjMCzCRBJtFR7B/sPtBxsJSef/b3CZJNUuBvw==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.4"
@@ -4668,9 +4894,9 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
@@ -4691,9 +4917,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -4724,21 +4951,21 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4776,6 +5003,7 @@
       "version": "12.6.1",
       "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
       "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^5.2.0",
         "@szmarczak/http-timer": "^5.0.1",
@@ -4800,6 +5028,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4877,7 +5106,8 @@
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -4912,6 +5142,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
       "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -5036,14 +5267,10 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
       "engines": {
         "node": ">= 12"
       }
@@ -5073,6 +5300,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -5168,6 +5396,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -5296,12 +5525,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "license": "MIT"
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5385,6 +5608,7 @@
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/ky/-/ky-0.33.0.tgz",
       "integrity": "sha512-peKzuOlN/q3Q3jOgi4t0cp6DOgif5rVnmiSIsjsmkiOcdnSjkrKSUqQmRWYCTqjUtR9b3xQQr8aj7KwSW1r49A==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -5461,27 +5685,10 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
       "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.1",
         "marky": "^1.2.2"
-      }
-    },
-    "node_modules/load-esm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.2.tgz",
-      "integrity": "sha512-nVAvWk/jeyrWyXEAs84mpQCYccxRqgKY4OznLuJhJCa0XsPSfdOIr2zvBZEj3IHEHbX97jjscKRRV539bW0Gpw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/Borewit"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://buymeacoffee.com/borewit"
-        }
-      ],
-      "engines": {
-        "node": ">=13.2.0"
       }
     },
     "node_modules/local-pkg": {
@@ -5617,6 +5824,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
       "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -5650,7 +5858,8 @@
     "node_modules/marky": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
-      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -5730,6 +5939,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -5751,10 +5961,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -5989,9 +6199,9 @@
       "integrity": "sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw=="
     },
     "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -6045,9 +6255,10 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.2.tgz",
-      "integrity": "sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -6128,6 +6339,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
       "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       }
@@ -6248,6 +6460,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -6492,6 +6719,23 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -6781,6 +7025,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -6853,18 +7098,18 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -6913,15 +7158,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/recast/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6934,7 +7170,8 @@
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -6959,6 +7196,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
       "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+      "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
@@ -6984,10 +7222,20 @@
       "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "license": "MIT"
     },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -7065,40 +7313,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/rrdom": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-fSFzFFxbqAViITyYVA4Z0o5G6p1nEqEr/N8vdgSKie9Rn0FJxDSNJgjV0yiCIzcDs0QR+hpvgFhpbdZ6JIr5Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "rrweb-snapshot": "^2.0.0-alpha.18"
-      }
-    },
-    "node_modules/rrweb": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-1mjZcB+LVoGSx1+i9E2ZdAP90fS3MghYVix2wvGlZvrgRuLCbTCCOZMztFCkKpgp7/EeCdYM4nIHJkKX5J1Nmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@rrweb/types": "^2.0.0-alpha.18",
-        "@rrweb/utils": "^2.0.0-alpha.18",
-        "@types/css-font-loading-module": "0.0.7",
-        "@xstate/fsm": "^1.4.0",
-        "base64-arraybuffer": "^1.0.1",
-        "mitt": "^3.0.0",
-        "rrdom": "^2.0.0-alpha.18",
-        "rrweb-snapshot": "^2.0.0-alpha.18"
-      }
-    },
-    "node_modules/rrweb-snapshot": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-hBHZL/NfgQX6wO1D9mpwqFu1NJPpim+moIcKhFEjVTZVRUfCln+LOugRc4teVTCISYHN8Cw5e2iNTWCSm+SkoA==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^8.4.38"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7124,9 +7338,9 @@
       }
     },
     "node_modules/safaridriver": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.0.tgz",
-      "integrity": "sha512-J92IFbskyo7OYB3Dt4aTdyhag1GlInrfbPCmMteb7aBK7PwlnGz1HI0+oyNN97j7pV9DqUAVoVgkNRMrfY47mQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.1.tgz",
+      "integrity": "sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -7649,12 +7863,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -7677,12 +7891,12 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 8"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -7718,12 +7932,6 @@
       "engines": {
         "node": ">= 10.x"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -7871,15 +8079,16 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -7932,20 +8141,20 @@
       }
     },
     "node_modules/testplane": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/testplane/-/testplane-8.31.0.tgz",
-      "integrity": "sha512-3y5FVX4zcP1YtWi8ohfIVmexBeda1oqIuC3bggVq2v311YQhPmlv9Y7q7r0xXrY8JHphGbW603jV4CKlaBMDng==",
+      "version": "8.44.2",
+      "resolved": "https://registry.npmjs.org/testplane/-/testplane-8.44.2.tgz",
+      "integrity": "sha512-q7WmQ33Y8TioRCDx9VNOGCtmpAyOW97PBmFI/veAhx01neZ542OegVBV4+jloJxe+/6NwBQFFkZ392zAWbMW3A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.24.2",
         "@gemini-testing/commander": "2.15.4",
         "@jspm/core": "2.0.1",
         "@jsquash/png": "3.1.1",
         "@puppeteer/browsers": "2.7.1",
-        "@rrweb/record": "2.0.0-alpha.18",
-        "@testplane/devtools": "8.32.3",
-        "@testplane/wdio-protocols": "9.4.6",
-        "@testplane/wdio-utils": "9.5.3",
-        "@testplane/webdriverio": "9.5.21",
+        "@testplane/devtools": "8.32.5",
+        "@testplane/wdio-protocols": "9.4.7",
+        "@testplane/wdio-utils": "9.5.4",
+        "@testplane/webdriverio": "9.5.28",
         "@vitest/spy": "2.1.4",
         "buffer-crc32": "1.0.0",
         "chalk": "2.4.2",
@@ -7957,27 +8166,27 @@
         "esbuild": "0.25.8",
         "expect-webdriverio": "3.6.0",
         "extract-zip": "2.0.1",
-        "fastq": "1.13.0",
-        "fs-extra": "5.0.0",
+        "fs-extra": "7.0.1",
         "geckodriver": "4.5.0",
-        "gemini-configparser": "1.4.1",
+        "gemini-configparser": "1.4.2",
         "get-port": "5.1.1",
         "import-meta-resolve": "4.0.0",
-        "load-esm": "1.0.2",
         "local-pkg": "0.4.3",
         "lodash": "4.17.21",
         "looks-same": "10.0.1",
         "micromatch": "4.0.5",
         "mocha": "10.2.0",
+        "p-limit": "3.1.0",
         "pirates": "4.0.7",
         "plugins-loader": "1.3.4",
         "png-validator": "1.1.0",
+        "proper-lockfile": "4.1.2",
         "recast": "0.23.6",
         "resolve.exports": "2.0.2",
         "sizzle": "2.3.6",
         "socket.io": "4.7.5",
         "socket.io-client": "4.7.5",
-        "source-map": "0.7.4",
+        "source-map-js": "1.2.1",
         "strftime": "0.10.2",
         "strip-ansi": "6.0.1",
         "temp": "0.8.3",
@@ -7987,6 +8196,7 @@
         "vite": "5.1.6",
         "wait-port": "1.1.0",
         "worker-farm": "1.7.0",
+        "ws": "8.18.3",
         "yallist": "3.1.1"
       },
       "bin": {
@@ -7997,11 +8207,15 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
+        "@babel/parser": ">=7.0.0",
         "@cspotcode/source-map-support": ">=0.7.0",
         "@swc/core": ">=1.3.96",
         "ts-node": ">=10.5.0"
       },
       "peerDependenciesMeta": {
+        "@babel/parser": {
+          "optional": true
+        },
         "@cspotcode/source-map-support": {
           "optional": true
         },
@@ -8726,6 +8940,7 @@
           "url": "https://github.com/sponsors/faisalman"
         }
       ],
+      "license": "MIT",
       "bin": {
         "ua-parser-js": "script/cli.js"
       },
@@ -8771,6 +8986,7 @@
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.12.0.tgz",
       "integrity": "sha512-d87yk8lqSFUYtR5fTFe2frpkMIrUEz+lgoJmhcL+J3StVl+8fj8ytE4lLnJOTPCE12YbumNGzf4LYsQyusdV5g==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0"
       }
@@ -8845,10 +9061,12 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -9164,9 +9382,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9176,9 +9394,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9211,12 +9429,12 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -9232,9 +9450,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -9250,6 +9468,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlhttprequest-ssl": {
@@ -9418,7 +9651,7 @@
         "@testplane/testing-library": "^1.0.5",
         "commander": "^14.0.3",
         "debug": "^4.3.4",
-        "testplane": "^8.31.0",
+        "testplane": "^8.44.1-rc.1",
         "zod": "^3.22.4"
       },
       "bin": {
@@ -9914,7 +10147,7 @@
         "@modelcontextprotocol/sdk": "^1.11.2",
         "@testplane/testing-library": "^1.0.5",
         "commander": "^13.1.0",
-        "testplane": "^8.31.0",
+        "testplane": "^8.44.1-rc.1",
         "zod": "^3.22.4"
       },
       "bin": {
@@ -10398,7 +10631,7 @@
       "license": "ISC",
       "dependencies": {
         "@testplane/testing-library": "^1.0.5",
-        "testplane": "^8.31.0",
+        "testplane": "^8.44.1-rc.1",
         "zod": "^3.22.4"
       },
       "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "@testplane/testing-library": "^1.0.5",
     "commander": "^14.0.3",
     "debug": "^4.3.4",
-    "testplane": "^8.31.0",
+    "testplane": "^8.44.1-rc.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -28,7 +28,7 @@
     "@modelcontextprotocol/sdk": "^1.11.2",
     "@testplane/testing-library": "^1.0.5",
     "commander": "^13.1.0",
-    "testplane": "^8.31.0",
+    "testplane": "^8.44.1-rc.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -28,7 +28,7 @@
   "license": "ISC",
   "dependencies": {
     "@testplane/testing-library": "^1.0.5",
-    "testplane": "^8.31.0",
+    "testplane": "^8.44.1-rc.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/tools/src/tools/navigate.ts
+++ b/packages/tools/src/tools/navigate.ts
@@ -4,22 +4,42 @@ import { createBrowserStateResponse, createErrorResponse } from "../responses/in
 
 export const navigateSchema = {
     url: z.string().url("Invalid URL format").describe("The URL to navigate to"),
+    timeout: z.number().optional().default(30000).describe("Maximum time to wait in milliseconds. Default: 30000"),
 };
 
 const navigateCb: ActionTool<typeof navigateSchema>["cb"] = async (args, browser) => {
     try {
-        const { url } = args;
+        const { url, timeout } = args;
+
+        const openOptions: { timeout?: number } = {};
+        if (timeout !== undefined) {
+            const browserConfig = await browser.getConfig();
+            browserConfig.urlHttpTimeout = timeout;
+
+            openOptions.timeout = timeout;
+        }
 
         console.error(`Navigating to: ${url}`);
-        await browser.openAndWait(url);
+        await browser.openAndWait(url, openOptions);
+
+        const optionsCode = Object.keys(openOptions).length > 0 ? `, ${JSON.stringify(openOptions)}` : "";
 
         return await createBrowserStateResponse(browser, {
             action: `Successfully navigated to ${url}`,
-            testplaneCode: `await browser.openAndWait("${url}");`,
+            testplaneCode: `await browser.openAndWait("${url}"${optionsCode});`,
         });
     } catch (error) {
         console.error("Error navigating to URL:", error);
-        return createErrorResponse("Error navigating to URL", error instanceof Error ? error : undefined);
+        const errorMessage = error instanceof Error ? error.message : String(error);
+
+        if (/timeout|timed out/i.test(errorMessage)) {
+            return createErrorResponse(
+                `Failed to load ${args.url} in ${args.timeout}ms. You can increase the wait time by setting a higher timeout value when calling this tool.\n\nOriginal error`,
+                error instanceof Error ? error : undefined,
+            );
+        }
+
+        return createErrorResponse(`Error navigating to ${args.url}`, error instanceof Error ? error : undefined);
     }
 };
 

--- a/packages/tools/test/tools/navigate.test.ts
+++ b/packages/tools/test/tools/navigate.test.ts
@@ -84,7 +84,9 @@ describe(
                     expect(result.isError).toBe(true);
                     const text = getTextContent(result);
                     expect(text).toContain("Failed to load http://localhost");
-                    expect(text).toContain("in 1500ms. You can increase the wait time by setting a higher timeout value when calling this tool");
+                    expect(text).toContain(
+                        "in 1500ms. You can increase the wait time by setting a higher timeout value when calling this tool",
+                    );
 
                     expect(elapsedTime).toBeGreaterThan(1400);
                     expect(elapsedTime).toBeLessThan(7000);

--- a/packages/tools/test/tools/navigate.test.ts
+++ b/packages/tools/test/tools/navigate.test.ts
@@ -1,3 +1,6 @@
+import http from "http";
+import { AddressInfo } from "net";
+
 import { WdioBrowser } from "testplane";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 
@@ -41,6 +44,54 @@ describe(
             const text = getTextContent(result);
             expect(text).toContain("## Browser Tabs");
             expect(text).toContain("## Current Tab Snapshot");
+        });
+
+        describe("timeout behavior", () => {
+            it("should omit timeout from generated testplane code when not provided", async () => {
+                const result = await navigate.cb({ url: playgroundUrl }, browser);
+
+                expect(result.isError).toBe(false);
+                const text = getTextContent(result);
+                expect(text).toContain(`await browser.openAndWait("${playgroundUrl}");`);
+                expect(text).not.toContain('"timeout"');
+            });
+
+            it("should include timeout in generated testplane code when provided", async () => {
+                const result = await navigate.cb({ url: playgroundUrl, timeout: 5000 }, browser);
+
+                expect(result.isError).toBe(false);
+                const text = getTextContent(result);
+                expect(text).toContain(`await browser.openAndWait("${playgroundUrl}", {"timeout":5000});`);
+            });
+
+            it("should respect custom timeout when the page never finishes loading", async () => {
+                const slowServer = http.createServer((_req, res) => {
+                    // Hold the response open — never finish so the navigation hits timeout.
+                    res.writeHead(200, { "Content-Type": "text/html" });
+                    res.write("<!doctype html><html><head><title>slow</title></head><body>");
+                    // Intentionally do NOT call res.end() so the response stays pending.
+                });
+
+                await new Promise<void>(resolve => slowServer.listen(0, resolve));
+                const port = (slowServer.address() as AddressInfo).port;
+                const slowUrl = `http://localhost:${port}/`;
+
+                try {
+                    const startTime = Date.now();
+                    const result = await navigate.cb({ url: slowUrl, timeout: 1500 }, browser);
+                    const elapsedTime = Date.now() - startTime;
+
+                    expect(result.isError).toBe(true);
+                    const text = getTextContent(result);
+                    expect(text).toContain("Failed to load http://localhost");
+                    expect(text).toContain("in 1500ms. You can increase the wait time by setting a higher timeout value when calling this tool");
+
+                    expect(elapsedTime).toBeGreaterThan(1400);
+                    expect(elapsedTime).toBeLessThan(7000);
+                } finally {
+                    await new Promise<void>(resolve => slowServer.close(() => resolve()));
+                }
+            });
         });
     },
     INTEGRATION_TEST_TIMEOUT,


### PR DESCRIPTION
### What's done?

- Added a `timeout` option to the navigate tool and fixed all edge cases related to it: when we should interrupt the request due to timeout and when making the timeout larger to make loading a slow page possible

Depends on enhancements on webdriverio's and testplane's side:
- https://github.com/gemini-testing/webdriverio/pull/41
- https://github.com/gemini-testing/webdriverio/pull/42
- https://github.com/gemini-testing/testplane/pull/1248