### PR TITLE
feat: save snapshots to file by default and remove element-based snapshots

### DIFF
--- a/packages/cli/test/daemon.e2e.test.ts
+++ b/packages/cli/test/daemon.e2e.test.ts
@@ -123,7 +123,11 @@ describe("daemon e2e", () => {
         const r = await runCli(["navigate", playgroundUrl], extraEnv);
         expect(r.code).toBe(0);
         expect(r.stdout).toContain(`Successfully navigated to ${playgroundUrl}`);
-        expect(r.stdout).toContain("e2e-ok");
+
+        const snapshotPathMatch = r.stdout.match(/Saved to: (\S+\.(?:yml|html))/);
+        expect(snapshotPathMatch, "navigate response should reference a saved snapshot file").not.toBeNull();
+        const snapshotContent = fs.readFileSync(snapshotPathMatch![1], "utf8");
+        expect(snapshotContent).toContain("e2e-ok");
     });
 
     it("clicks an element by CSS selector", async () => {

--- a/packages/cli/test/simple-http-server.ts
+++ b/packages/cli/test/simple-http-server.ts
@@ -1,4 +1,5 @@
 import http from "http";
+import { AddressInfo } from "net";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import handler from "serve-handler";
@@ -11,6 +12,11 @@ export function launchServer(port: number, rootDir = join(__dirname, "playground
             return handler(req, res, { public: rootDir });
         });
         server.once("error", reject);
-        server.listen(port, () => resolve(server));
+        server.once("listening", () => {
+            const boundPort = (server.address() as AddressInfo).port;
+            console.log(`Running at http://localhost:${boundPort}`);
+            resolve(server);
+        });
+        server.listen(port);
     });
 }

--- a/packages/mcp/test/server.e2e.test.ts
+++ b/packages/mcp/test/server.e2e.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 
@@ -54,7 +55,11 @@ describe(
             const content = result.content as Array<{ type: string; text: string }>;
             const text = content.map(c => c.text).join("\n");
             expect(text).toContain(`Successfully navigated to ${playgroundUrl}`);
-            expect(text).toContain("server-wiring-ok");
+
+            const snapshotPathMatch = text.match(/(?:Saved to:|The snapshot was saved to:) (\S+\.(?:yml|html))/);
+            expect(snapshotPathMatch, "navigate response should reference a saved snapshot file").not.toBeNull();
+            const snapshotContent = fs.readFileSync(snapshotPathMatch![1], "utf8");
+            expect(snapshotContent).toContain("server-wiring-ok");
         });
 
         it("closeBrowser ends the session cleanly", async () => {

--- a/packages/mcp/test/simple-http-server.ts
+++ b/packages/mcp/test/simple-http-server.ts
@@ -1,20 +1,25 @@
 import http from "http";
+import { AddressInfo } from "net";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import handler from "serve-handler";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export function launchServer(port = 8090, rootDir = join(__dirname, "playground")): http.Server {
-    const server = http.createServer((request, response) => {
-        return handler(request, response, {
-            public: rootDir,
+export function launchServer(port: number, rootDir = join(__dirname, "playground")): Promise<http.Server> {
+    return new Promise((resolve, reject) => {
+        const server = http.createServer((request, response) => {
+            return handler(request, response, {
+                public: rootDir,
+            });
         });
-    });
+        server.once("error", reject);
+        server.once("listening", () => {
+            const boundPort = (server.address() as AddressInfo).port;
+            console.log(`Running at http://localhost:${boundPort}`);
+            resolve(server);
+        });
 
-    server.listen(port, () => {
-        console.log(`Running at http://localhost:${port}`);
+        server.listen(port);
     });
-
-    return server;
 }

--- a/packages/mcp/test/test-server.ts
+++ b/packages/mcp/test/test-server.ts
@@ -17,7 +17,7 @@ export class PlaygroundServer {
     }
 
     async start(): Promise<string> {
-        this.server = launchServer(this.port, this.playgroundPath);
+        this.server = await launchServer(this.port, this.playgroundPath);
         return `http://localhost:${this.port}`;
     }
 

--- a/packages/tools/src/responses/browser-helpers.ts
+++ b/packages/tools/src/responses/browser-helpers.ts
@@ -1,3 +1,6 @@
+import path from "path";
+import fs from "fs/promises";
+import os from "os";
 import { WdioBrowser } from "testplane";
 
 export interface BrowserTab {
@@ -43,13 +46,18 @@ export interface CaptureSnapshotOptions {
     maxTextLength?: number;
 }
 
-async function captureSnapshot(
-    browserOrElement: WebdriverIO.Element | WdioBrowser,
+interface CapturedPageSnapshotResult {
+    rawContent: string;
+    fenceLanguage: "yaml" | "html";
+    notes: string[];
+}
+
+async function capturePageSnapshot(
+    browser: WdioBrowser,
     options: CaptureSnapshotOptions = {},
-    context: { type: "browser" | "element"; fallbackMethod?: string },
-): Promise<string | null> {
+): Promise<CapturedPageSnapshotResult | null> {
     try {
-        const snapshotResult = await (browserOrElement as WdioBrowser).unstable_captureDomSnapshot(options);
+        const snapshotResult = await browser.unstable_captureDomSnapshot(options);
 
         const notes: string[] = [];
 
@@ -63,54 +71,100 @@ async function captureSnapshot(
 
         if (omittedParts.length > 0) {
             notes.push(
-                `# Note: ${omittedParts.join(" and ")} were omitted from this ${context.type} snapshot. If you need them, request the ${context.type} snapshot again and explicitly specify them as needed.`,
+                `${omittedParts.join(" and ")} were omitted from this browser snapshot. If you need them, request the browser snapshot again and explicitly specify them as needed.`,
             );
         }
 
         if (snapshotResult.textWasTruncated) {
             notes.push(
-                `# Note: some text contents/attribute values were truncated. If you need full text contents, request a snapshot with truncateText: false.`,
+                `some text contents/attribute values were truncated. If you need full text contents, request a snapshot with truncateText: false.`,
             );
         }
 
-        return "```yaml\n" + notes.join("\n") + "\n" + snapshotResult.snapshot + "\n```";
+        return {
+            rawContent: snapshotResult.snapshot,
+            fenceLanguage: "yaml",
+            notes,
+        };
     } catch (error) {
-        console.error(`Error getting ${context.type} snapshot:`, error);
+        console.error("Error getting browser snapshot:", error);
 
-        if (context.type === "browser" && browserOrElement.getPageSource) {
-            const pageSource = await browserOrElement.getPageSource();
-            return (
-                "```html\n" +
-                `<!-- Note: failed to get optimized ${context.type} snapshot, below is raw page source as a fallback. The error was: ${(error as Error)?.stack} -->\n\n` +
-                pageSource +
-                "\n```"
-            );
-        }
-
-        if (context.type === "element" && (browserOrElement as WebdriverIO.Element).getHTML) {
-            const elementHTML = await (browserOrElement as WebdriverIO.Element).getHTML();
-            return (
-                "```html\n" +
-                `<!-- Note: failed to get ${context.type} snapshot, below is element HTML as a fallback. The error was: ${(error as Error)?.message} -->\n\n` +
-                elementHTML +
-                "\n```"
-            );
+        if (browser.getPageSource) {
+            try {
+                const pageSource = await browser.getPageSource();
+                return {
+                    rawContent: pageSource,
+                    fenceLanguage: "html",
+                    notes: [
+                        `failed to get optimized browser snapshot, below is raw page source as a fallback. The error was: ${(error as Error)?.stack}`,
+                    ],
+                };
+            } catch (fallbackError) {
+                console.error("Error getting page source fallback:", fallbackError);
+            }
         }
     }
 
     return null;
 }
 
-export async function getCurrentTabSnapshot(
-    browser: WdioBrowser,
-    options: CaptureSnapshotOptions = {},
-): Promise<string | null> {
-    return captureSnapshot(browser, options, { type: "browser" });
+function formatNotesAsComments(notes: string[], fenceLanguage: "yaml" | "html"): string {
+    if (notes.length === 0) return "";
+
+    if (fenceLanguage === "html") {
+        return notes.map(note => `<!-- Note: ${note} -->`).join("\n") + "\n";
+    }
+
+    return (
+        notes
+            .map(note =>
+                note
+                    .split("\n")
+                    .map((line, index) => (index === 0 ? `# Note: ${line}` : `#   ${line}`))
+                    .join("\n"),
+            )
+            .join("\n") + "\n"
+    );
 }
 
-export async function getElementSnapshot(
-    element: WebdriverIO.Element,
+export interface PageSnapshotResult {
+    content: string;
+    fenceLanguage: "yaml" | "html";
+}
+
+export async function getPageSnapshot(
+    browser: WdioBrowser,
     options: CaptureSnapshotOptions = {},
-): Promise<string | null> {
-    return captureSnapshot(element, options, { type: "element" });
+): Promise<PageSnapshotResult | null> {
+    const result = await capturePageSnapshot(browser, options);
+    if (!result) return null;
+
+    const noteBlock = formatNotesAsComments(result.notes, result.fenceLanguage);
+    return {
+        content: noteBlock + result.rawContent,
+        fenceLanguage: result.fenceLanguage,
+    };
+}
+
+export interface SavedPageSnapshot {
+    filePath: string;
+}
+
+export async function savePageSnapshotToFile(
+    browser: WdioBrowser,
+    options: CaptureSnapshotOptions = {},
+): Promise<SavedPageSnapshot | null> {
+    const result = await getPageSnapshot(browser, options);
+    if (!result) return null;
+
+    const dir = path.join(os.tmpdir(), ".testplane", "snapshots");
+    await fs.mkdir(dir, { recursive: true });
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const extension = result.fenceLanguage === "html" ? "html" : "yml";
+    const filePath = path.join(dir, `${timestamp}.${extension}`);
+
+    await fs.writeFile(filePath, result.content, "utf8");
+
+    return { filePath };
 }

--- a/packages/tools/src/responses/index.ts
+++ b/packages/tools/src/responses/index.ts
@@ -1,11 +1,6 @@
 import { WdioBrowser } from "testplane";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import {
-    CaptureSnapshotOptions,
-    getBrowserTabs,
-    getCurrentTabSnapshot,
-    getElementSnapshot,
-} from "./browser-helpers.js";
+import { CaptureSnapshotOptions, getPageSnapshot, getBrowserTabs, savePageSnapshotToFile } from "./browser-helpers.js";
 
 export type ToolResponse = CallToolResult;
 
@@ -15,13 +10,7 @@ export interface BrowserResponseOptions {
     additionalInfo?: string;
     snapshotOptions?: CaptureSnapshotOptions;
     isSnapshotNeeded?: boolean;
-}
-
-export interface ElementResponseOptions {
-    action?: string;
-    testplaneCode?: string;
-    additionalInfo?: string;
-    snapshotOptions?: CaptureSnapshotOptions;
+    inlineSnapshot?: boolean;
 }
 
 export function createSimpleResponse(message: string, isError = false): ToolResponse {
@@ -66,10 +55,21 @@ export async function createBrowserStateResponse(
     }
 
     if (options.isSnapshotNeeded !== false) {
-        const snapshot = await getCurrentTabSnapshot(browser, options.snapshotOptions);
-        if (snapshot) {
-            sections.push("## Current Tab Snapshot");
-            sections.push(snapshot);
+        if (options.inlineSnapshot) {
+            const snapshot = await getPageSnapshot(browser, options.snapshotOptions);
+            if (snapshot) {
+                sections.push("## Current Tab Snapshot");
+                sections.push("```" + snapshot.fenceLanguage + "\n" + snapshot.content + "\n```");
+            }
+        } else {
+            const saved = await savePageSnapshotToFile(browser, options.snapshotOptions);
+            if (saved) {
+                sections.push("## Current Tab Snapshot");
+                sections.push(
+                    `Saved to: ${saved.filePath}\n` +
+                        `Note: some tags/attributes may be omitted and text may be truncated — see the comments at the top of the file for details.`,
+                );
+            }
         }
     }
 
@@ -93,35 +93,4 @@ export function createErrorResponse(message: string, error?: Error): ToolRespons
         ],
         isError: true,
     };
-}
-
-export async function createElementStateResponse(
-    element: WebdriverIO.Element,
-    options: ElementResponseOptions,
-): Promise<ToolResponse> {
-    const sections: string[] = [];
-
-    if (options.action) {
-        sections.push(`✅ ${options.action}`);
-    }
-
-    if (options.testplaneCode) {
-        sections.push("## Testplane Code");
-        sections.push("```javascript");
-        sections.push(options.testplaneCode);
-        sections.push("```");
-    }
-
-    const elementSnapshot = await getElementSnapshot(element, options.snapshotOptions);
-    if (elementSnapshot) {
-        sections.push("## Element Snapshot");
-        sections.push(elementSnapshot);
-    }
-
-    if (options.additionalInfo) {
-        sections.push("## Additional Information");
-        sections.push(options.additionalInfo);
-    }
-
-    return createSimpleResponse(sections.join("\n\n"));
 }

--- a/packages/tools/src/tools/click-on-element.ts
+++ b/packages/tools/src/tools/click-on-element.ts
@@ -1,5 +1,5 @@
 import { ActionTool, ToolKind } from "../types.js";
-import { createElementStateResponse, createErrorResponse } from "../responses/index.js";
+import { createBrowserStateResponse, createErrorResponse } from "../responses/index.js";
 import { elementSelectorShape } from "../schemas/element-selector.js";
 import { findElement } from "../utils/element-selector.js";
 
@@ -13,7 +13,7 @@ const clickOnElementCb: ActionTool<typeof elementClickSchema>["cb"] = async (arg
 
         console.error(`Successfully clicked element with ${queryDescription}`);
 
-        return await createElementStateResponse(element, {
+        return await createBrowserStateResponse(browser, {
             action: `Successfully clicked element found by ${queryDescription}`,
             testplaneCode: testplaneCode.startsWith("await")
                 ? `await (${testplaneCode}).click();`

--- a/packages/tools/src/tools/hover-element.ts
+++ b/packages/tools/src/tools/hover-element.ts
@@ -1,5 +1,5 @@
 import { ActionTool, ToolKind } from "../types.js";
-import { createElementStateResponse, createErrorResponse } from "../responses/index.js";
+import { createBrowserStateResponse, createErrorResponse } from "../responses/index.js";
 import { elementSelectorShape } from "../schemas/element-selector.js";
 import { findElement } from "../utils/element-selector.js";
 
@@ -13,7 +13,7 @@ const hoverElementCb: ActionTool<typeof elementHoverSchema>["cb"] = async (args,
 
         console.error(`Successfully hovered element with ${queryDescription}`);
 
-        return await createElementStateResponse(element, {
+        return await createBrowserStateResponse(browser, {
             action: `Successfully hovered element found by ${queryDescription}`,
             testplaneCode: testplaneCode.startsWith("await")
                 ? `await (${testplaneCode}).moveTo();`

--- a/packages/tools/src/tools/take-page-snapshot.ts
+++ b/packages/tools/src/tools/take-page-snapshot.ts
@@ -31,6 +31,7 @@ const takePageSnapshotCb: ActionTool<typeof takePageSnapshotSchema>["cb"] = asyn
             action: "Page snapshot captured successfully",
             testplaneCode,
             snapshotOptions,
+            inlineSnapshot: true,
         });
     } catch (error) {
         console.error("Error taking page snapshot:", error);

--- a/packages/tools/src/tools/type-into-element.ts
+++ b/packages/tools/src/tools/type-into-element.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ActionTool, ToolKind } from "../types.js";
-import { createElementStateResponse, createErrorResponse } from "../responses/index.js";
+import { createBrowserStateResponse, createErrorResponse } from "../responses/index.js";
 import { elementSelectorShape } from "../schemas/element-selector.js";
 import { findElement } from "../utils/element-selector.js";
 
@@ -19,7 +19,7 @@ const typeIntoElementCb: ActionTool<typeof typeIntoElementSchema>["cb"] = async 
 
         console.error(`Successfully typed "${value}" into element with ${queryDescription}`);
 
-        return await createElementStateResponse(element, {
+        return await createBrowserStateResponse(browser, {
             action: `Successfully typed "${value}" into element found by ${queryDescription}`,
             testplaneCode: testplaneCode.startsWith("await")
                 ? `await (${testplaneCode}).setValue("${value}");`

--- a/packages/tools/test/responses/index.test.ts
+++ b/packages/tools/test/responses/index.test.ts
@@ -10,7 +10,8 @@ import * as browserHelpers from "../../src/responses/browser-helpers.js";
 
 vi.mock("../../src/responses/browser-helpers.js", () => ({
     getBrowserTabs: vi.fn(),
-    getCurrentTabSnapshot: vi.fn(),
+    getPageSnapshot: vi.fn(),
+    savePageSnapshotToFile: vi.fn(),
 }));
 
 describe("responses/index", () => {
@@ -60,17 +61,19 @@ describe("responses/index", () => {
     describe("createBrowserStateResponse", () => {
         let mockBrowser: WdioBrowser;
         let mockGetBrowserTabs: ReturnType<typeof vi.fn>;
-        let mockGetCurrentTabSnapshot: ReturnType<typeof vi.fn>;
+        let mockGetPageSnapshot: ReturnType<typeof vi.fn>;
+        let mockSavePageSnapshotToFile: ReturnType<typeof vi.fn>;
 
         beforeEach(() => {
             mockBrowser = {} as WdioBrowser;
             mockGetBrowserTabs = vi.mocked(browserHelpers.getBrowserTabs);
-            mockGetCurrentTabSnapshot = vi.mocked(browserHelpers.getCurrentTabSnapshot);
+            mockGetPageSnapshot = vi.mocked(browserHelpers.getPageSnapshot);
+            mockSavePageSnapshotToFile = vi.mocked(browserHelpers.savePageSnapshotToFile);
         });
 
         it("should create response with action only", async () => {
             mockGetBrowserTabs.mockResolvedValue([]);
-            mockGetCurrentTabSnapshot.mockResolvedValue(null);
+            mockSavePageSnapshotToFile.mockResolvedValue(null);
 
             const options: BrowserResponseOptions = {
                 action: "Page loaded successfully",
@@ -84,7 +87,7 @@ describe("responses/index", () => {
 
         it("should include testplane code when provided", async () => {
             mockGetBrowserTabs.mockResolvedValue([]);
-            mockGetCurrentTabSnapshot.mockResolvedValue(null);
+            mockSavePageSnapshotToFile.mockResolvedValue(null);
 
             const options: BrowserResponseOptions = {
                 action: "Click performed",
@@ -107,7 +110,7 @@ describe("responses/index", () => {
                 { title: "GitHub", url: "https://github.com", isActive: false },
             ];
             mockGetBrowserTabs.mockResolvedValue(mockTabs);
-            mockGetCurrentTabSnapshot.mockResolvedValue(null);
+            mockSavePageSnapshotToFile.mockResolvedValue(null);
 
             const options: BrowserResponseOptions = {
                 action: "Navigation completed",
@@ -121,24 +124,68 @@ describe("responses/index", () => {
             expect(responseText).toContain("2. Title: GitHub; URL: https://github.com");
         });
 
-        it("should include current tab snapshot when available", async () => {
+        it("should save snapshot to file by default and include path in response", async () => {
             mockGetBrowserTabs.mockResolvedValue([]);
-            mockGetCurrentTabSnapshot.mockResolvedValue("<html><body>Test content</body></html>");
+            mockSavePageSnapshotToFile.mockResolvedValue({
+                filePath: "/tmp/.testplane/snapshots/2026-05-04T12-34-56-789Z.yml",
+            });
 
             const options: BrowserResponseOptions = {
-                action: "Snapshot captured",
+                action: "Snapshot saved",
             };
 
             const result = await createBrowserStateResponse(mockBrowser, options);
             const responseText = result.content[0].text;
 
+            expect(mockSavePageSnapshotToFile).toHaveBeenCalledOnce();
+            expect(mockGetPageSnapshot).not.toHaveBeenCalled();
+            expect(responseText).toContain("## Current Tab Snapshot");
+            expect(responseText).toContain("Saved to: /tmp/.testplane/snapshots/2026-05-04T12-34-56-789Z.yml");
+            expect(responseText).toContain("some tags/attributes may be omitted");
+            expect(responseText).not.toContain("```yaml");
+        });
+
+        it("should inline snapshot when inlineSnapshot is true", async () => {
+            mockGetBrowserTabs.mockResolvedValue([]);
+            mockGetPageSnapshot.mockResolvedValue({
+                content: "<html><body>Test content</body></html>",
+                fenceLanguage: "yaml",
+            });
+
+            const options: BrowserResponseOptions = {
+                action: "Snapshot captured",
+                inlineSnapshot: true,
+            };
+
+            const result = await createBrowserStateResponse(mockBrowser, options);
+            const responseText = result.content[0].text;
+
+            expect(mockGetPageSnapshot).toHaveBeenCalledOnce();
+            expect(mockSavePageSnapshotToFile).not.toHaveBeenCalled();
             expect(responseText).toContain("## Current Tab Snapshot");
             expect(responseText).toContain("<html><body>Test content</body></html>");
+            expect(responseText).not.toContain("Saved to:");
+        });
+
+        it("should skip snapshot when isSnapshotNeeded is false", async () => {
+            mockGetBrowserTabs.mockResolvedValue([]);
+
+            const options: BrowserResponseOptions = {
+                action: "No snapshot wanted",
+                isSnapshotNeeded: false,
+            };
+
+            const result = await createBrowserStateResponse(mockBrowser, options);
+            const responseText = result.content[0].text;
+
+            expect(mockSavePageSnapshotToFile).not.toHaveBeenCalled();
+            expect(mockGetPageSnapshot).not.toHaveBeenCalled();
+            expect(responseText).not.toContain("## Current Tab Snapshot");
         });
 
         it("should include additional information when provided", async () => {
             mockGetBrowserTabs.mockResolvedValue([]);
-            mockGetCurrentTabSnapshot.mockResolvedValue(null);
+            mockSavePageSnapshotToFile.mockResolvedValue(null);
 
             const options: BrowserResponseOptions = {
                 action: "Complex operation",
@@ -155,7 +202,9 @@ describe("responses/index", () => {
         it("should include all sections when all options are provided", async () => {
             const mockTabs = [{ title: "Test Page", url: "https://test.com", isActive: true }];
             mockGetBrowserTabs.mockResolvedValue(mockTabs);
-            mockGetCurrentTabSnapshot.mockResolvedValue("<html><body>Full test</body></html>");
+            mockSavePageSnapshotToFile.mockResolvedValue({
+                filePath: "/tmp/.testplane/snapshots/snap.yml",
+            });
 
             const options: BrowserResponseOptions = {
                 action: "Complete operation",
@@ -172,14 +221,14 @@ describe("responses/index", () => {
             expect(responseText).toContain("## Browser Tabs");
             expect(responseText).toContain("1. Title: Test Page; URL: https://test.com (current)");
             expect(responseText).toContain("## Current Tab Snapshot");
-            expect(responseText).toContain("<html><body>Full test</body></html>");
+            expect(responseText).toContain("Saved to: /tmp/.testplane/snapshots/snap.yml");
             expect(responseText).toContain("## Additional Information");
             expect(responseText).toContain("All features tested successfully.");
         });
 
         it("should handle empty tabs array", async () => {
             mockGetBrowserTabs.mockResolvedValue([]);
-            mockGetCurrentTabSnapshot.mockResolvedValue(null);
+            mockSavePageSnapshotToFile.mockResolvedValue(null);
 
             const options: BrowserResponseOptions = {
                 action: "No tabs test",
@@ -192,9 +241,9 @@ describe("responses/index", () => {
             expect(responseText).toContain("No opened tabs");
         });
 
-        it("should handle null snapshot", async () => {
+        it("should handle null snapshot save result", async () => {
             mockGetBrowserTabs.mockResolvedValue([]);
-            mockGetCurrentTabSnapshot.mockResolvedValue(null);
+            mockSavePageSnapshotToFile.mockResolvedValue(null);
 
             const options: BrowserResponseOptions = {
                 action: "No snapshot test",

--- a/packages/tools/test/setup.ts
+++ b/packages/tools/test/setup.ts
@@ -1,3 +1,4 @@
+import fs from "fs/promises";
 import { WdioBrowser } from "testplane";
 import { launchBrowser } from "testplane/unstable";
 
@@ -15,4 +16,16 @@ export async function launchHeadlessBrowser(): Promise<WdioBrowser> {
 export function getTextContent(result: { content: unknown }): string {
     const content = result.content as Array<{ type: string; text: string }>;
     return content.map(item => item.text).join("\n");
+}
+
+const SAVED_SNAPSHOT_PATH_RE = /Saved to: (\S+\.(?:yml|html))/;
+
+export function extractSnapshotPath(responseText: string): string {
+    const match = responseText.match(SAVED_SNAPSHOT_PATH_RE);
+    if (!match) throw new Error(`No "Saved to: <path>" line found in response:\n${responseText}`);
+    return match[1];
+}
+
+export async function readSnapshotFromResponse(responseText: string): Promise<string> {
+    return fs.readFile(extractSnapshotPath(responseText), "utf8");
 }

--- a/packages/tools/test/simple-http-server.ts
+++ b/packages/tools/test/simple-http-server.ts
@@ -1,20 +1,25 @@
 import http from "http";
+import { AddressInfo } from "net";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import handler from "serve-handler";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export function launchServer(port = 8090, rootDir = join(__dirname, "playground")): http.Server {
-    const server = http.createServer((request, response) => {
-        return handler(request, response, {
-            public: rootDir,
+export function launchServer(port: number, rootDir: string = join(__dirname, "playground")): Promise<http.Server> {
+    return new Promise((resolve, reject) => {
+        const server = http.createServer((request, response) => {
+            return handler(request, response, {
+                public: rootDir,
+            });
         });
-    });
+        server.once("error", reject);
+        server.once("listening", () => {
+            const boundPort = (server.address() as AddressInfo).port;
+            console.log(`Running at http://localhost:${boundPort}`);
+            resolve(server);
+        });
 
-    server.listen(port, () => {
-        console.log(`Running at http://localhost:${port}`);
+        server.listen(port);
     });
-
-    return server;
 }

--- a/packages/tools/test/tools/click-on-element.test.ts
+++ b/packages/tools/test/tools/click-on-element.test.ts
@@ -41,7 +41,8 @@ describe(
                 expect(result.isError).toBe(false);
                 const text = getTextContent(result);
                 expect(text).toContain("Successfully clicked element");
-                expect(text).toContain("span.clicked-indicator.show");
+                expect(text).toContain("## Current Tab Snapshot");
+                expect(text).toMatch(/Saved to: .+\.testplane\/snapshots\/.+\.(yml|html)/);
             });
 
             it("should click an element using CSS selector", async () => {
@@ -55,7 +56,8 @@ describe(
                 expect(result.isError).toBe(false);
                 const text = getTextContent(result);
                 expect(text).toContain("Successfully clicked element");
-                expect(text).toContain("span.clicked-indicator.show");
+                expect(text).toContain("## Current Tab Snapshot");
+                expect(text).toMatch(/Saved to: .+\.testplane\/snapshots\/.+\.(yml|html)/);
             });
 
             it("should return correct testplane code for clicked element", async () => {

--- a/packages/tools/test/tools/hover-element.test.ts
+++ b/packages/tools/test/tools/hover-element.test.ts
@@ -41,7 +41,8 @@ describe(
                 expect(result.isError).toBe(false);
                 const text = getTextContent(result);
                 expect(text).toContain("Successfully hovered element");
-                expect(text).toContain("button#submit-btn[@hover]");
+                expect(text).toContain("## Current Tab Snapshot");
+                expect(text).toMatch(/Saved to: .+\.testplane\/snapshots\/.+\.(yml|html)/);
             });
 
             it("should hover an element using CSS selector", async () => {
@@ -55,7 +56,8 @@ describe(
                 expect(result.isError).toBe(false);
                 const text = getTextContent(result);
                 expect(text).toContain("Successfully hovered element");
-                expect(text).toContain("div#unique-element[@hover]");
+                expect(text).toContain("## Current Tab Snapshot");
+                expect(text).toMatch(/Saved to: .+\.testplane\/snapshots\/.+\.(yml|html)/);
             });
 
             it("should return correct testplane code for hovered element", async () => {

--- a/packages/tools/test/tools/launch-browser.test.ts
+++ b/packages/tools/test/tools/launch-browser.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, beforeAll, afterEach, afterAll } from "vitest";
 import { launchBrowser } from "../../src/tools/launch-browser.js";
 import { navigate } from "../../src/tools/navigate.js";
 import { PlaygroundServer } from "../test-server.js";
-import { getTextContent } from "../setup.js";
+import { getTextContent, readSnapshotFromResponse } from "../setup.js";
 import { INTEGRATION_TEST_TIMEOUT } from "../constants.js";
 
 describe(
@@ -87,11 +87,11 @@ describe(
                 );
 
                 expect(navigateResult.isError).toBe(false);
-                const responseText = getTextContent(navigateResult);
+                const snapshot = await readSnapshotFromResponse(getTextContent(navigateResult));
 
-                expect(responseText).toContain("Viewport width: 375");
-                expect(responseText).toContain("Viewport height: 667");
-                expect(responseText).toContain("Device pixel ratio: 2");
+                expect(snapshot).toContain("Viewport width: 375");
+                expect(snapshot).toContain("Viewport height: 667");
+                expect(snapshot).toContain("Device pixel ratio: 2");
             });
         });
 
@@ -111,11 +111,11 @@ describe(
                 );
 
                 expect(navigateResult.isError).toBe(false);
-                const responseText = getTextContent(navigateResult);
+                const snapshot = await readSnapshotFromResponse(getTextContent(navigateResult));
 
-                expect(responseText).toContain("Viewport width: 1280");
+                expect(snapshot).toContain("Viewport width: 1280");
                 // Viewport height is less than window height due to browser chrome
-                expect(responseText).toContain("Viewport height: 577");
+                expect(snapshot).toContain("Viewport height: 577");
             });
 
             it("should launch browser with window size as string", async () => {
@@ -131,11 +131,11 @@ describe(
                 );
 
                 expect(navigateResult.isError).toBe(false);
-                const responseText = getTextContent(navigateResult);
+                const snapshot = await readSnapshotFromResponse(getTextContent(navigateResult));
 
-                expect(responseText).toContain("Viewport width: 1024");
+                expect(snapshot).toContain("Viewport width: 1024");
                 // Viewport height is less than window height due to browser chrome
-                expect(responseText).toContain("Viewport height: 625");
+                expect(snapshot).toContain("Viewport height: 625");
             });
 
             it("should launch browser with windowSize null to reset to default", async () => {

--- a/packages/tools/test/tools/navigate.test.ts
+++ b/packages/tools/test/tools/navigate.test.ts
@@ -44,6 +44,7 @@ describe(
             const text = getTextContent(result);
             expect(text).toContain("## Browser Tabs");
             expect(text).toContain("## Current Tab Snapshot");
+            expect(text).toMatch(/Saved to: .+\.testplane\/snapshots\/.+\.(yml|html)/);
         });
 
         describe("timeout behavior", () => {

--- a/packages/tools/test/tools/wait-for-element.test.ts
+++ b/packages/tools/test/tools/wait-for-element.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 
 import { waitForElement } from "../../src/tools/wait-for-element.js";
 import { PlaygroundServer } from "../test-server.js";
-import { launchHeadlessBrowser, getTextContent } from "../setup.js";
+import { launchHeadlessBrowser, getTextContent, readSnapshotFromResponse } from "../setup.js";
 import { INTEGRATION_TEST_TIMEOUT } from "../constants.js";
 import { navigate } from "../../src/tools/navigate.js";
 
@@ -26,11 +26,11 @@ describe(
             if (testServer) await testServer.stop();
         });
 
-        let navigateResponse: string;
+        let navigateSnapshot: string;
 
         beforeEach(async () => {
             const navigateResult = await navigate.cb({ url: slowLoadingUrl }, browser);
-            navigateResponse = getTextContent(navigateResult);
+            navigateSnapshot = await readSnapshotFromResponse(getTextContent(navigateResult));
         });
 
         describe("waiting for elements to appear", () => {
@@ -45,11 +45,12 @@ describe(
                 expect(result.isError).toBe(false);
                 const text = getTextContent(result);
                 expect(text).toContain("Successfully waited for element");
-                expect(text).toContain("[data-testid=immediate-btn]");
+                const snapshot = await readSnapshotFromResponse(text);
+                expect(snapshot).toContain("[data-testid=immediate-btn]");
             });
 
             it("should wait for content to appear using CSS selector", async () => {
-                expect(navigateResponse).not.toContain("[data-testid=medium-btn]");
+                expect(navigateSnapshot).not.toContain("[data-testid=medium-btn]");
 
                 const result = await waitForElement.cb(
                     {
@@ -67,7 +68,7 @@ describe(
             });
 
             it("should wait for content to appear using testing-library testId query", async () => {
-                expect(navigateResponse).not.toContain("[data-testid=medium-btn]");
+                expect(navigateSnapshot).not.toContain("[data-testid=medium-btn]");
 
                 const result = await waitForElement.cb(
                     {
@@ -82,13 +83,14 @@ describe(
                 expect(text).toContain("Successfully waited for element");
                 expect(text).toContain("to appear");
                 expect(text).toContain('await browser.queryByTestId("medium-btn")');
-                expect(text).toContain("[data-testid=medium-btn]");
+                const snapshot = await readSnapshotFromResponse(text);
+                expect(snapshot).toContain("[data-testid=medium-btn]");
             });
         });
 
         describe("waiting for elements to disappear", () => {
             it("should wait for disappearing content using CSS selector", async () => {
-                expect(navigateResponse).toContain("[data-testid=disappearing-btn]");
+                expect(navigateSnapshot).toContain("[data-testid=disappearing-btn]");
 
                 const result = await waitForElement.cb(
                     {
@@ -103,11 +105,12 @@ describe(
                 const text = getTextContent(result);
                 expect(text).toContain("Successfully waited for element");
                 expect(text).toContain("to disappear");
-                expect(text).not.toContain("[data-testid=disappearing-btn]");
+                const snapshot = await readSnapshotFromResponse(text);
+                expect(snapshot).not.toContain("[data-testid=disappearing-btn]");
             });
 
             it("should wait for disappearing content using testId", async () => {
-                expect(navigateResponse).toContain("[data-testid=disappearing-btn]");
+                expect(navigateSnapshot).toContain("[data-testid=disappearing-btn]");
 
                 const result = await waitForElement.cb(
                     {
@@ -123,11 +126,12 @@ describe(
                 expect(text).toContain("Successfully waited for element");
                 expect(text).toContain("to disappear");
                 expect(text).toContain('await browser.queryByTestId("disappearing-btn")');
-                expect(text).not.toContain("[data-testid=disappearing-btn]");
+                const snapshot = await readSnapshotFromResponse(text);
+                expect(snapshot).not.toContain("[data-testid=disappearing-btn]");
             });
 
             it("should wait for text content to disappear", async () => {
-                expect(navigateResponse).toContain('p "This content will disappear after 3 seconds');
+                expect(navigateSnapshot).toContain('p "This content will disappear after 3 seconds');
 
                 const result = await waitForElement.cb(
                     {
@@ -146,7 +150,8 @@ describe(
                 expect(text).toContain(
                     'await browser.queryByText("This content will disappear after 3 seconds", {"exact":false})',
                 );
-                expect(text).toContain('p[@hidden] "This content will disappear after 3 seconds');
+                const snapshot = await readSnapshotFromResponse(text);
+                expect(snapshot).toContain('p[@hidden] "This content will disappear after 3 seconds');
             });
         });
 


### PR DESCRIPTION
### What's done?
- Instead of returning the whole snapshot after each tool call, they are now saved to files and the path to file is given in the response, except for the "snapshot" tool. There snapshot is returned right away.
- Removed element-based snapshots. Before, when clicking on an element or doing similar actions, we'd return element snapshot. However, this proved to be a bad idea: navigation may happen at any moment after interaction, which will break the whole concept. Now, page snapshots are returned everywhere