### PR TITLE
feat: close browser sessions automatically by TTL

### DIFF
--- a/packages/cli/src/daemon/index.ts
+++ b/packages/cli/src/daemon/index.ts
@@ -9,10 +9,12 @@ import { IdleWatchdog } from "./idle-watchdog.js";
 import { SessionRegistry } from "./session-registry.js";
 import { formatError } from "../utils/error.js";
 import { RequestHandler } from "./request-handler.js";
+import { parseSessionTtlMs, SESSION_TTL_ENV } from "../utils/session-timeout.js";
 
 const debug = makeDebug("testplane-cli:daemon");
 
 const IDLE_TTL_MS = Number(process.env.TESTPLANE_CLI_DAEMON_IDLE_MS ?? 30000);
+const SESSION_TTL_MS = parseSessionTtlMs(process.env[SESSION_TTL_ENV]);
 const LOG_MAX_BYTES = 5 * 1024 * 1024;
 const DEFAULT_HEADLESS = !/^(0|false|no)$/i.test(process.env.TESTPLANE_CLI_HEADLESS ?? "");
 
@@ -36,7 +38,7 @@ function prepareRuntimeFiles(dir: string, logPath: string): void {
 }
 
 export async function startDaemon(): Promise<void> {
-    const sessions = new SessionRegistry({ headless: DEFAULT_HEADLESS });
+    const sessions = new SessionRegistry({ headless: DEFAULT_HEADLESS }, { sessionTtlMs: SESSION_TTL_MS });
     const requestDispatcher = new RequestHandler();
     const { dir, socket: socketPath, log: logPath } = socketPathFor(findProjectRoot());
     prepareRuntimeFiles(dir, logPath);

--- a/packages/cli/src/daemon/request-handler.ts
+++ b/packages/cli/src/daemon/request-handler.ts
@@ -47,7 +47,7 @@ export class RequestHandler {
             return { id: req.id, kind: "error", code: "INVALID_ARGS", message };
         }
 
-        const state = sessions.getOrCreate(req.sessionName);
+        const state = sessions.beginInteraction(req.sessionName);
 
         try {
             if (tool.kind === ToolKind.Action) {
@@ -96,7 +96,7 @@ export class RequestHandler {
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const closeResult = await tool.cb(parsedArgs as any, state.browser);
-            state.browser = null;
+            sessions.clearBrowser(req.sessionName, state);
 
             return { id: req.id, kind: "result", content: closeResult.content, isError: closeResult.isError };
         } catch (error) {
@@ -104,6 +104,8 @@ export class RequestHandler {
             debug("Tool error: id=%d tool=%s message=%s", req.id, req.tool, message);
 
             return { id: req.id, kind: "error", code: "TOOL_ERROR", message };
+        } finally {
+            sessions.endInteraction(req.sessionName, state);
         }
     }
 }

--- a/packages/cli/src/daemon/session-registry.ts
+++ b/packages/cli/src/daemon/session-registry.ts
@@ -8,6 +8,12 @@ const debug = makeDebug("testplane-cli:daemon:session-registry");
 export interface SessionState {
     browser: WdioBrowser | null;
     options: BrowserOptions;
+    activeInteractions: number;
+    expirationTimer: NodeJS.Timeout | null;
+}
+
+export interface SessionRegistryOptions {
+    sessionTtlMs: number;
 }
 
 function formatError(error: unknown): string {
@@ -21,19 +27,45 @@ function formatError(error: unknown): string {
 export class SessionRegistry {
     private readonly _sessions = new Map<string, SessionState>();
     private readonly _defaultOptions: BrowserOptions;
+    private readonly _sessionTtlMs: number;
 
-    constructor(defaultOptions: BrowserOptions) {
+    constructor(defaultOptions: BrowserOptions, options: SessionRegistryOptions) {
         this._defaultOptions = defaultOptions;
+        this._sessionTtlMs = options.sessionTtlMs;
     }
 
     public getOrCreate(sessionName: string): SessionState {
         let state = this._sessions.get(sessionName);
         if (!state) {
-            state = { browser: null, options: { ...this._defaultOptions } };
+            state = {
+                browser: null,
+                options: { ...this._defaultOptions },
+                activeInteractions: 0,
+                expirationTimer: null,
+            };
             this._sessions.set(sessionName, state);
         }
 
         return state;
+    }
+
+    public beginInteraction(sessionName: string): SessionState {
+        const state = this.getOrCreate(sessionName);
+
+        state.activeInteractions += 1;
+        this._cancelExpirationTimer(sessionName, state);
+
+        return state;
+    }
+
+    public endInteraction(sessionName: string, state: SessionState): void {
+        state.activeInteractions = Math.max(0, state.activeInteractions - 1);
+        this._scheduleExpirationTimer(sessionName, state);
+    }
+
+    public clearBrowser(sessionName: string, state: SessionState): void {
+        state.browser = null;
+        this._cancelExpirationTimer(sessionName, state);
     }
 
     public hasLive(): boolean {
@@ -71,7 +103,7 @@ export class SessionRegistry {
             }
 
             if (state.browser === browser) {
-                state.browser = null;
+                this.clearBrowser(sessionName, state);
             }
         }
     }
@@ -90,7 +122,50 @@ export class SessionRegistry {
                 debug("Session cleanup error: session=%s message=%s", sessionName, formatError(error));
             }
 
-            state.browser = null;
+            this.clearBrowser(sessionName, state);
+        }
+    }
+
+    private _scheduleExpirationTimer(sessionName: string, state: SessionState): void {
+        if (state.expirationTimer || state.activeInteractions > 0 || !state.browser) {
+            return;
+        }
+
+        const browser = state.browser;
+
+        debug("Session expiration timer armed: session=%s ttlMs=%d", sessionName, this._sessionTtlMs);
+        state.expirationTimer = setTimeout(() => {
+            void this._expireSession(sessionName, state, browser);
+        }, this._sessionTtlMs);
+        state.expirationTimer.unref();
+    }
+
+    private _cancelExpirationTimer(sessionName: string, state: SessionState): void {
+        if (!state.expirationTimer) {
+            return;
+        }
+
+        debug("Session expiration timer canceled: session=%s", sessionName);
+        clearTimeout(state.expirationTimer);
+        state.expirationTimer = null;
+    }
+
+    private async _expireSession(sessionName: string, state: SessionState, browser: WdioBrowser | null): Promise<void> {
+        state.expirationTimer = null;
+
+        if (!browser || state.browser !== browser || state.activeInteractions > 0) {
+            this._scheduleExpirationTimer(sessionName, state);
+
+            return;
+        }
+
+        debug("Session expiration timer fired: session=%s", sessionName);
+        state.browser = null;
+
+        try {
+            await browser.deleteSession();
+        } catch (error) {
+            debug("Session expiration cleanup error: session=%s message=%s", sessionName, formatError(error));
         }
     }
 

--- a/packages/cli/src/utils/session-timeout.ts
+++ b/packages/cli/src/utils/session-timeout.ts
@@ -1,0 +1,20 @@
+export const DEFAULT_SESSION_TTL_MS = 5 * 60 * 1000;
+export const SESSION_TTL_ENV = "TESTPLANE_CLI_SESSION_TTL_MS";
+
+export function parseSessionTtlMs(value: string | undefined): number {
+    const rawValue = value?.trim();
+    if (rawValue === undefined || rawValue === "") {
+        return DEFAULT_SESSION_TTL_MS;
+    }
+
+    if (!/^\d+$/.test(rawValue)) {
+        throw new Error(`${SESSION_TTL_ENV} must be a positive integer number of milliseconds`);
+    }
+
+    const ttlMs = Number(rawValue);
+    if (!Number.isSafeInteger(ttlMs) || ttlMs <= 0) {
+        throw new Error(`${SESSION_TTL_ENV} must be a positive integer number of milliseconds`);
+    }
+
+    return ttlMs;
+}

--- a/packages/cli/test/daemon.e2e.test.ts
+++ b/packages/cli/test/daemon.e2e.test.ts
@@ -161,6 +161,24 @@ describe("daemon e2e", () => {
         expect(fs.existsSync(socketPath)).toBe(true);
     });
 
+    it("expires a browser session after a configurable inactivity timeout", async () => {
+        const sessionEnv = {
+            ...extraEnv,
+            TESTPLANE_CLI_SOCKET_OVERRIDE: path.join(path.dirname(socketPath), "session-timeout.sock"),
+            TESTPLANE_CLI_SESSION_TTL_MS: "1000",
+        };
+
+        const navigateResp = await runCli(["navigate", playgroundUrl], sessionEnv);
+        expect(navigateResp.code).toBe(0);
+        expect(navigateResp.stdout).toContain(`Successfully navigated to ${playgroundUrl}`);
+
+        await sleep(1500);
+
+        const closeResp = await runCli(["close-browser"], sessionEnv);
+        expect(closeResp.code).toBe(0);
+        expect(closeResp.stdout).toContain("No active browser session to close");
+    });
+
     it("exits after idle TTL when attached browser dies externally", async () => {
         let externalBrowser: BrowserWithDriverPid | null = null;
 

--- a/packages/cli/test/daemon/session-registry.test.ts
+++ b/packages/cli/test/daemon/session-registry.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import type { WdioBrowser } from "testplane";
+
+import { SessionRegistry } from "../../src/daemon/session-registry.js";
+import { DEFAULT_SESSION_TTL_MS, parseSessionTtlMs } from "../../src/session-timeout.js";
+
+function createBrowser(): WdioBrowser & { deleteSession: ReturnType<typeof vi.fn> } {
+    return {
+        deleteSession: vi.fn().mockResolvedValue(undefined),
+        getUrl: vi.fn().mockResolvedValue("about:blank"),
+    } as unknown as WdioBrowser & { deleteSession: ReturnType<typeof vi.fn> };
+}
+
+describe("daemon/SessionRegistry", () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("expires a browser session after its inactivity timeout", async () => {
+        vi.useFakeTimers();
+        const sessions = new SessionRegistry({}, { sessionTtlMs: 1000 });
+        const browser = createBrowser();
+
+        const state = sessions.beginInteraction("default");
+        state.browser = browser;
+        sessions.endInteraction("default", state);
+
+        await vi.advanceTimersByTimeAsync(999);
+        expect(browser.deleteSession).not.toHaveBeenCalled();
+        expect(state.browser).toBe(browser);
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(browser.deleteSession).toHaveBeenCalledTimes(1);
+        expect(state.browser).toBeNull();
+    });
+
+    it("resets the inactivity timeout when the session is touched again", async () => {
+        vi.useFakeTimers();
+        const sessions = new SessionRegistry({}, { sessionTtlMs: 1000 });
+        const browser = createBrowser();
+
+        const state = sessions.beginInteraction("default");
+        state.browser = browser;
+        sessions.endInteraction("default", state);
+
+        await vi.advanceTimersByTimeAsync(600);
+        const sameState = sessions.beginInteraction("default");
+        sessions.endInteraction("default", sameState);
+
+        await vi.advanceTimersByTimeAsync(999);
+        expect(browser.deleteSession).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(browser.deleteSession).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses the configured session timeout", async () => {
+        vi.useFakeTimers();
+        const sessions = new SessionRegistry({}, { sessionTtlMs: 250 });
+        const browser = createBrowser();
+
+        const state = sessions.beginInteraction("default");
+        state.browser = browser;
+        sessions.endInteraction("default", state);
+
+        await vi.advanceTimersByTimeAsync(249);
+        expect(browser.deleteSession).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(browser.deleteSession).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("parseSessionTtlMs", () => {
+    it("defaults to 5 minutes", () => {
+        expect(parseSessionTtlMs(undefined)).toBe(DEFAULT_SESSION_TTL_MS);
+        expect(parseSessionTtlMs("")).toBe(DEFAULT_SESSION_TTL_MS);
+        expect(DEFAULT_SESSION_TTL_MS).toBe(5 * 60 * 1000);
+    });
+
+    it("accepts only positive integer millisecond values", () => {
+        expect(parseSessionTtlMs("1000")).toBe(1000);
+        expect(() => parseSessionTtlMs("0")).toThrow();
+        expect(() => parseSessionTtlMs("1.5")).toThrow();
+        expect(() => parseSessionTtlMs("1e3")).toThrow();
+        expect(() => parseSessionTtlMs("1000ms")).toThrow();
+    });
+});

--- a/packages/cli/test/daemon/session-registry.test.ts
+++ b/packages/cli/test/daemon/session-registry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import type { WdioBrowser } from "testplane";
 
 import { SessionRegistry } from "../../src/daemon/session-registry.js";
-import { DEFAULT_SESSION_TTL_MS, parseSessionTtlMs } from "../../src/session-timeout.js";
+import { DEFAULT_SESSION_TTL_MS, parseSessionTtlMs } from "../../src/utils/session-timeout.js";
 
 function createBrowser(): WdioBrowser & { deleteSession: ReturnType<typeof vi.fn> } {
     return {

--- a/packages/tools/src/tools/launch-browser.ts
+++ b/packages/tools/src/tools/launch-browser.ts
@@ -45,7 +45,7 @@ export const launchBrowserSchema = {
         .string()
         .default("local")
         .describe(
-            'WebDriver endpoint to connect to. "local" (default) lets Testplane MCP manage Chrome and Firefox automatically; set a Selenium grid URL only when you need other browsers.',
+            'WebDriver endpoint to connect to. "local" (default) lets Testplane manage Chrome and Firefox automatically; set a Selenium grid URL only when you need other browsers.',
         ),
     windowSize: windowSizeSchema,
 };
@@ -111,7 +111,7 @@ export const launchBrowser: SessionOpenTool<typeof launchBrowserSchema> = {
     kind: ToolKind.SessionOpen,
     name: "launch",
     description:
-        "Launch a new browser session with custom desired capabilities. Avoid using this tool unless the user explicitly requests a custom browser configuration; browsers are launched automatically for commands like navigate to URL. Testplane MCP can ONLY download Chrome and Firefox automatically, for other browsers you MUST ensure that driver is launched and provide it as custom gridUrl.",
+        "Launch a new browser session with custom desired capabilities. Avoid using this tool unless the user explicitly requests a custom browser configuration; browsers are launched automatically for commands like navigate to URL. Testplane can ONLY download Chrome and Firefox automatically, for other browsers you MUST ensure that driver is launched and provide it as custom gridUrl.",
     schema: launchBrowserSchema,
     cb: launchBrowserCb,
     cli: { section: "Session" },


### PR DESCRIPTION
### What's done?

- Browser sessions are closed after a period of inactivity
- By default, TTL is 5 minutes
- This TTL may be configured using the `TESTPLANE_CLI_SESSION_TTL_MS` env var