### PR TITLE
feat: add support for headful mode in CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2042,6 +2042,16 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/serve-handler": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/serve-handler/-/serve-handler-6.1.4.tgz",
+      "integrity": "sha512-aXy58tNie0NkuSCY291xUxl0X+kGYy986l4kqW6Gi4kEXgr6Tx0fpSH7YwUSa5usPpG3s9DBeIR6hHcDtL2IvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
@@ -9660,6 +9670,7 @@
       "devDependencies": {
         "@testplane/tools": "*",
         "@types/debug": "^4.1.12",
+        "@types/serve-handler": "^6.1.4",
         "esbuild": "^0.24.0",
         "serve-handler": "^6.1.6"
       }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "prebuild": "npm --prefix ../tools run build",
     "build": "node scripts/build.mjs",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig.test.json --noEmit",
     "start": "node build/cli.js",
     "dev": "npm run build && node build/cli.js",
     "lint": "eslint .",
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@testplane/tools": "*",
     "@types/debug": "^4.1.12",
+    "@types/serve-handler": "^6.1.4",
     "esbuild": "^0.24.0",
     "serve-handler": "^6.1.6"
   }

--- a/packages/cli/src/zod-to-commander.ts
+++ b/packages/cli/src/zod-to-commander.ts
@@ -129,7 +129,7 @@ export function registerFlag(cmd: Command, name: string, meta: ZodFieldMeta): vo
                     if (raw === "false" || raw === "0") {
                         return false;
                     }
-                    throw new Error(`--${key} must be boolean ("true" or "false"), got "${raw}"`);
+                    throw new Error(`--${key} must be boolean ("true" / 1 or "false" / 0), got "${raw}"`);
                 });
                 break;
             }

--- a/packages/cli/src/zod-to-commander.ts
+++ b/packages/cli/src/zod-to-commander.ts
@@ -119,9 +119,23 @@ export function registerFlag(cmd: Command, name: string, meta: ZodFieldMeta): vo
 
     let opt: Option;
     switch (meta.kind) {
-        case "boolean":
-            opt = new Option(meta.defaultValue === true ? `--no-${kebabCase(name)}` : flag, desc);
+        case "boolean": {
+            const key = kebabCase(name);
+            if (meta.optional && meta.defaultValue === undefined) {
+                opt = new Option(`--${key} <value>`, desc).argParser(raw => {
+                    if (raw === "true" || raw === "1") {
+                        return true;
+                    }
+                    if (raw === "false" || raw === "0") {
+                        return false;
+                    }
+                    throw new Error(`--${key} must be boolean ("true" or "false"), got "${raw}"`);
+                });
+                break;
+            }
+            opt = new Option(meta.defaultValue === true ? `--no-${key}` : flag, desc);
             break;
+        }
         case "number":
             opt = new Option(`${flag} <value>`, desc).argParser(raw => {
                 const n = Number(raw);

--- a/packages/cli/test/ipc/json-socket.test.ts
+++ b/packages/cli/test/ipc/json-socket.test.ts
@@ -132,17 +132,15 @@ describe("ipc/JsonSocket", () => {
     });
 
     it("send() writes one JSON line to the underlying socket", () => {
-        const ok = conn.send({ id: 7, kind: "result", result: { content: [{ type: "text", text: "done" }] } });
+        const ok = conn.send({ id: 7, kind: "result", content: [{ type: "text", text: "done" }] });
         expect(ok).toBe(true);
-        expect(mock.writes).toEqual([
-            '{"id":7,"kind":"result","result":{"content":[{"type":"text","text":"done"}]}}\n',
-        ]);
+        expect(mock.writes).toEqual(['{"id":7,"kind":"result","content":[{"type":"text","text":"done"}]}\n']);
     });
 
     it("send() returns false after close", () => {
         mock.emit("close");
         expect(conn.isClosed).toBe(true);
-        const ok = conn.send({ id: 1, kind: "result" });
+        const ok = conn.send({ id: 1, kind: "result", content: [] });
         expect(ok).toBe(false);
         expect(mock.writes).toEqual([]);
     });
@@ -196,11 +194,11 @@ describe("ipc/JsonSocket", () => {
         right.on("message", m => rightReceived.push(m));
 
         left.send({ id: 1, kind: "call", tool: "click", sessionName: "default", args: { selector: "#x" } });
-        right.send({ id: 1, kind: "result", result: { content: [{ type: "text", text: "ok" }] } });
+        right.send({ id: 1, kind: "result", content: [{ type: "text", text: "ok" }] });
 
         expect(rightReceived).toEqual([
             { id: 1, kind: "call", tool: "click", sessionName: "default", args: { selector: "#x" } },
         ]);
-        expect(leftReceived).toEqual([{ id: 1, kind: "result", result: { content: [{ type: "text", text: "ok" }] } }]);
+        expect(leftReceived).toEqual([{ id: 1, kind: "result", content: [{ type: "text", text: "ok" }] }]);
     });
 });

--- a/packages/cli/test/scenarios.e2e.test.ts
+++ b/packages/cli/test/scenarios.e2e.test.ts
@@ -33,6 +33,14 @@ describe("CLI user scenarios", () => {
         if (testServer) await testServer.stop();
     });
 
+    it("should expose headless override option in launch command help", async () => {
+        const help = await cli("launch", "--help");
+
+        expect(help.code).toBe(0);
+        expect(help.out).toContain("--headless <value>");
+        expect(help.out).not.toContain("--no-headless");
+    });
+
     it("should navigate and inspect the page via DOM snapshot", async () => {
         const nav = await cli("navigate", playgroundUrl);
         expect(nav.code).toBe(0);

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "include": ["src/**/*", "test/**/*"],
+    "compilerOptions": {
+        "outDir": "build"
+    }
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -141,6 +141,8 @@ Close the current browser session.
 Launch a new browser session with custom configuration options.
 
 - **Parameters:**
+  - `headless` (boolean, optional): Whether to run browser in headless mode. When omitted, current session/server mode is preserved.
+
   - `desiredCapabilities` (object, optional): WebDriver [desired capabilities](https://www.selenium.dev/documentation/webdriver/capabilities/) to forward to the Testplane launcher. Example:
 
     ```json

--- a/packages/tools/src/tools/launch-browser.ts
+++ b/packages/tools/src/tools/launch-browser.ts
@@ -40,6 +40,12 @@ const windowSizeSchema = z
     );
 
 export const launchBrowserSchema = {
+    headless: z
+        .boolean()
+        .optional()
+        .describe(
+            'Whether to run browser in headless mode. When omitted, preserves the current session mode (CLI defaults to headless on first launch; use "--headless false" for headful mode).',
+        ),
     desiredCapabilities: desiredCapabilitiesSchema.optional(),
     gridUrl: z
         .string()
@@ -52,11 +58,16 @@ export const launchBrowserSchema = {
 
 const launchBrowserCb: SessionOpenTool<typeof launchBrowserSchema>["cb"] = async (args, previousOptions) => {
     try {
+        const headless = args.headless;
         const desiredCapabilities = args.desiredCapabilities as BrowserOptions["desiredCapabilities"];
         const gridUrl = args.gridUrl ?? "local";
         const windowSizeInput = args.windowSize;
 
         const updatedOptions: BrowserOptions = { ...previousOptions };
+
+        if (Object.prototype.hasOwnProperty.call(args, "headless")) {
+            updatedOptions.headless = headless;
+        }
 
         if (Object.prototype.hasOwnProperty.call(args, "desiredCapabilities")) {
             updatedOptions.desiredCapabilities = desiredCapabilities;

--- a/packages/tools/test/tools/launch-browser-headless.test.ts
+++ b/packages/tools/test/tools/launch-browser-headless.test.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { launchBrowser, launchBrowserSchema } from "../../src/tools/launch-browser.js";
+import { launchBrowser as launchTestplaneBrowser } from "testplane/unstable";
+
+vi.mock("testplane/unstable", () => ({
+    launchBrowser: vi.fn(),
+}));
+
+describe("tools/launchBrowser headless option", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(launchTestplaneBrowser).mockResolvedValue({} as never);
+    });
+
+    it("preserves previous session mode when headless is omitted", async () => {
+        const parsedArgs = z.object(launchBrowserSchema).parse({});
+        const result = await launchBrowser.cb(parsedArgs, { headless: false });
+
+        expect(result.options.headless).toBe(false);
+        expect(vi.mocked(launchTestplaneBrowser)).toHaveBeenCalledWith(
+            expect.objectContaining({
+                headless: false,
+            }),
+        );
+    });
+
+    it("allows explicitly enabling headless mode", async () => {
+        const parsedArgs = z.object(launchBrowserSchema).parse({ headless: true });
+        const result = await launchBrowser.cb(parsedArgs, { headless: false });
+
+        expect(result.options.headless).toBe(true);
+        expect(vi.mocked(launchTestplaneBrowser)).toHaveBeenCalledWith(
+            expect.objectContaining({
+                headless: "new",
+            }),
+        );
+    });
+
+    it("allows explicitly disabling headless mode", async () => {
+        const parsedArgs = z.object(launchBrowserSchema).parse({ headless: false });
+        const result = await launchBrowser.cb(parsedArgs, { headless: true });
+
+        expect(result.options.headless).toBe(false);
+        expect(vi.mocked(launchTestplaneBrowser)).toHaveBeenCalledWith(
+            expect.objectContaining({
+                headless: false,
+            }),
+        );
+    });
+});


### PR DESCRIPTION
### What's done?

Now, launch command looks like this:

```
Usage: testplane-cli launch [options]

Launch a new browser session with custom desired capabilities. Avoid using this tool unless the user explicitly requests a custom browser configuration; browsers are launched automatically for commands like navigate to URL. Testplane can ONLY download Chrome and Firefox automatically, for
other browsers you MUST ensure that driver is launched and provide it as custom gridUrl.

Options:
  --headless <value>             Whether to run browser in headless mode. When omitted, preserves the current session mode (CLI defaults to headless on first launch; use "--headless false" for headful mode).
  --desired-capabilities <json>  WebDriver desiredCapabilities that should be used when launching the browser. Example to launch Chrome with mobile emulation: {"browserName":"chrome","goog:chromeOptions":{"mobileEmulation":{"deviceMetrics":{"width":360,"height":800,"pixelRatio":1.0}}}}
                                 (JSON-encoded)
  --grid-url <value>             WebDriver endpoint to connect to. "local" (default) lets Testplane manage Chrome and Firefox automatically; set a Selenium grid URL only when you need other browsers. (default: "local")
  --window-size <json>           Viewport to use for the session. Provide {"width": number, "height": number} or a string like "1280x720"; use null to reset to the default size. (JSON-encoded)
  -h, --help                     display help for command
```