### PR TITLE
feat: implement run-code tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2692,10 +2692,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "dev": true,
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -11877,6 +11876,7 @@
         "@rrweb/replay": "^2.0.0-alpha.18",
         "@rrweb/types": "^2.0.0-alpha.18",
         "@testplane/testing-library": "^1.0.5",
+        "acorn": "^8.16.0",
         "fflate": "^0.8.2",
         "html-reporter": "^11.10.0-rc.2",
         "lodash.escaperegexp": "^4.1.2",

--- a/packages/cli/src/tools.ts
+++ b/packages/cli/src/tools.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import path from "node:path";
 import type { ZodTypeAny } from "zod";
 
 import { tools } from "@testplane/tools";
@@ -23,6 +24,17 @@ interface ToolToRegister {
 }
 
 let nextRequestId = 1;
+
+function prepareCliArgs(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
+    if (toolName !== "run-code" || typeof args.file !== "string" || path.isAbsolute(args.file)) {
+        return args;
+    }
+
+    return {
+        ...args,
+        file: path.resolve(process.cwd(), args.file),
+    };
+}
 
 function registerTool(program: Command, tool: ToolToRegister, getSessionName: () => string): void {
     const cmd = program.command(tool.name).description(tool.description);
@@ -75,13 +87,15 @@ function registerTool(program: Command, tool: ToolToRegister, getSessionName: ()
                 args[positionalNames[i]] = value;
             }
 
-            debug("Invoking: tool=%s args=%o", tool.name, args);
+            const requestArgs = prepareCliArgs(tool.name, args);
+
+            debug("Invoking: tool=%s args=%o", tool.name, requestArgs);
             const res = await sendRequest({
                 id: nextRequestId++,
                 kind: "call",
                 tool: tool.name,
                 sessionName: getSessionName(),
-                args,
+                args: requestArgs,
             });
 
             renderAndExit(res);

--- a/packages/cli/test/daemon.e2e.test.ts
+++ b/packages/cli/test/daemon.e2e.test.ts
@@ -119,6 +119,34 @@ describe("daemon e2e", () => {
         expect(r.stdout).toContain("No active browser session to close");
     });
 
+    it("resolves run-code --file relative to the current CLI invocation", async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "testplane-cli-run-code-cwd-"));
+        const daemonCwd = path.join(tmpDir, "daemon-cwd");
+        const callerCwd = path.join(tmpDir, "caller-cwd");
+        const runCodeEnv = {
+            ...extraEnv,
+            TESTPLANE_CLI_SOCKET_OVERRIDE: path.join(tmpDir, "run-code-cwd.sock"),
+        };
+
+        fs.mkdirSync(daemonCwd);
+        fs.mkdirSync(callerCwd);
+        fs.writeFileSync(path.join(daemonCwd, "script.js"), '"daemon-cwd";');
+        fs.writeFileSync(path.join(callerCwd, "script.js"), '"caller-cwd";');
+
+        try {
+            const spawnResp = await runCli(["close-browser"], runCodeEnv, daemonCwd);
+            expect(spawnResp.code).toBe(0);
+
+            const runResp = await runCli(["run-code", "--file", "./script.js"], runCodeEnv, callerCwd);
+            expect(runResp.code).toBe(0);
+            expect(runResp.stdout).toContain('"caller-cwd"');
+            expect(runResp.stdout).not.toContain('"daemon-cwd"');
+        } finally {
+            await runCli(["close-browser"], runCodeEnv, callerCwd).catch(() => {});
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
     it("navigates to the playground page", async () => {
         const r = await runCli(["navigate", playgroundUrl], extraEnv);
         expect(r.code).toBe(0);

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -11,10 +11,11 @@ export interface CliResult {
     code: number;
 }
 
-export function runCli(args: string[], extraEnv: Record<string, string> = {}): Promise<CliResult> {
+export function runCli(args: string[], extraEnv: Record<string, string> = {}, cwd?: string): Promise<CliResult> {
     return new Promise((resolve, reject) => {
         const child = spawn(process.execPath, [CLI_JS, ...args], {
             env: { ...process.env, ...extraEnv },
+            cwd,
         });
         let stdout = "";
         let stderr = "";

--- a/packages/mcp/test/server.e2e.test.ts
+++ b/packages/mcp/test/server.e2e.test.ts
@@ -28,6 +28,8 @@ const EXPECTED_TOOL_NAMES = [
     "launch",
     "attach",
     "close-browser",
+    // advanced tools
+    "run-code",
 ];
 
 describe(

--- a/packages/tools/package-lock.json
+++ b/packages/tools/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@testing-library/webdriverio": "^3.2.1",
+        "acorn": "^8.16.0",
         "html-reporter": "^11.9.3",
         "lodash.escaperegexp": "^4.1.2",
         "testplane": "^8.44.1-rc.1",
@@ -2427,6 +2428,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -30,6 +30,7 @@
     "@testplane/testing-library": "^1.0.5",
     "@rrweb/replay": "^2.0.0-alpha.18",
     "@rrweb/types": "^2.0.0-alpha.18",
+    "acorn": "^8.16.0",
     "fflate": "^0.8.2",
     "html-reporter": "^11.10.0-rc.2",
     "lodash.escaperegexp": "^4.1.2",

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -15,6 +15,7 @@ import { closeTab } from "./tools/close-tab.js";
 import { launchBrowser, launchBrowserWithOptions } from "./tools/launch-browser.js";
 import { attachToBrowser } from "./tools/attach-to-browser.js";
 import { closeBrowser } from "./tools/close-browser.js";
+import { runCode } from "./tools/run-code.js";
 import { inspectResult } from "./tools/inspect-result/index.js";
 import { testResults } from "./tools/test-results/index.js";
 import { timeTravelSnapshot } from "./tools/time-travel-snapshot/index.js";
@@ -41,6 +42,7 @@ export const tools = typeCheckedTools([
     launchBrowser,
     attachToBrowser,
     closeBrowser,
+    runCode,
     testResults,
     inspectResult,
     timeTravelSnapshot,

--- a/packages/tools/src/tools/run-code.ts
+++ b/packages/tools/src/tools/run-code.ts
@@ -1,0 +1,219 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { parse } from "acorn";
+import { z } from "zod";
+
+import { ActionTool, ToolKind } from "../types.js";
+import { createSimpleResponse } from "../responses/index.js";
+
+const FUNCTION_NODE_TYPES = new Set(["ArrowFunctionExpression", "FunctionExpression", "FunctionDeclaration"]);
+
+type AsyncFunctionConstructor = new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as AsyncFunctionConstructor;
+
+interface ParsedNode {
+    type: string;
+    start: number;
+    end: number;
+    body?: ParsedNode[];
+    expression?: ParsedNode;
+}
+
+interface ParsedExpression {
+    type: string;
+    code: string;
+}
+
+export const runCodeSchema = {
+    code: z
+        .string()
+        .optional()
+        .describe(
+            'JavaScript code to run. It may be an expression like "await browser.getUrl()" or a function like "(browser) => browser.getUrl()".',
+        ),
+    file: z.string().optional().describe("Path to a JavaScript file to run instead of inline code"),
+};
+
+function parseSingleExpression(source: string): ParsedExpression | null {
+    try {
+        const program = parse(source, { ecmaVersion: "latest", allowAwaitOutsideFunction: true }) as ParsedNode;
+        const statements = (program.body ?? []).filter(statement => statement.type !== "EmptyStatement");
+
+        if (statements.length === 1) {
+            const statement = statements[0];
+
+            if (statement.type === "ExpressionStatement" && statement.expression) {
+                return {
+                    type: statement.expression.type,
+                    code: source.slice(statement.expression.start, statement.expression.end),
+                };
+            }
+
+            if (statement.type === "FunctionDeclaration") {
+                return {
+                    type: statement.type,
+                    code: source.slice(statement.start, statement.end),
+                };
+            }
+        }
+    } catch {
+        // Fall back to parenthesized expression parsing below.
+    }
+
+    try {
+        const program = parse(`(${source})`, { ecmaVersion: "latest", allowAwaitOutsideFunction: true }) as ParsedNode;
+        const statement = program.body?.[0];
+        const expression = statement?.type === "ExpressionStatement" ? statement.expression : undefined;
+
+        if (expression) {
+            return { type: expression.type, code: source };
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+async function runExpression(expressionCode: string, browser: unknown): Promise<unknown> {
+    const fn = new AsyncFunction("browser", `"use strict";\nreturn (${expressionCode});`);
+
+    return fn(browser);
+}
+
+async function runBody(code: string, browser: unknown): Promise<unknown> {
+    const fn = new AsyncFunction("browser", `"use strict";\n${code}`);
+
+    return fn(browser);
+}
+
+async function executeSource(source: string, browser: unknown): Promise<unknown> {
+    const parsedExpression = parseSingleExpression(source);
+
+    if (parsedExpression && FUNCTION_NODE_TYPES.has(parsedExpression.type)) {
+        const fn = await runExpression(parsedExpression.code, browser);
+
+        if (typeof fn !== "function") {
+            throw new Error(`Expected input to evaluate to a function, got ${typeof fn}`);
+        }
+
+        return fn(browser);
+    }
+
+    if (parsedExpression) {
+        return runExpression(parsedExpression.code, browser);
+    }
+
+    return runBody(source, browser);
+}
+
+function serializeError(error: unknown): Record<string, unknown> {
+    if (!(error instanceof Error)) {
+        return {
+            name: typeof error,
+            message: String(error),
+        };
+    }
+
+    const serialized: Record<string, unknown> = {
+        name: error.name,
+        message: error.message,
+    };
+
+    if (error.stack) {
+        serialized.stack = error.stack;
+    }
+
+    const errorProps = error as unknown as Record<string, unknown>;
+    for (const key of Object.keys(errorProps)) {
+        serialized[key] = errorProps[key];
+    }
+
+    return serialized;
+}
+
+function json(payload: unknown): string {
+    const seen = new WeakSet<object>();
+
+    return JSON.stringify(
+        payload,
+        (_key, value) => {
+            if (typeof value === "bigint") {
+                return value.toString();
+            }
+
+            if (typeof value === "function") {
+                return `[Function${value.name ? `: ${value.name}` : ""}]`;
+            }
+
+            if (typeof value === "undefined") {
+                return null;
+            }
+
+            if (value instanceof Error) {
+                return serializeError(value);
+            }
+
+            if (value && typeof value === "object") {
+                if (seen.has(value)) {
+                    return "[Circular]";
+                }
+
+                seen.add(value);
+            }
+
+            return value;
+        },
+        2,
+    );
+}
+
+async function getSource(args: { code?: string; file?: string }): Promise<string> {
+    if (args.code !== undefined && args.file !== undefined) {
+        throw new Error("Pass either code or --file, not both");
+    }
+
+    if (args.code !== undefined) {
+        return args.code;
+    }
+
+    if (args.file === undefined) {
+        throw new Error("Pass code or --file");
+    }
+
+    const filePath = path.isAbsolute(args.file) ? args.file : path.resolve(process.cwd(), args.file);
+
+    return readFile(filePath, "utf8");
+}
+
+const runCodeCb: ActionTool<typeof runCodeSchema>["cb"] = async (args, browser) => {
+    try {
+        const source = await getSource(args);
+        const result = await executeSource(source, browser);
+
+        return createSimpleResponse(json({ result }));
+    } catch (error) {
+        return createSimpleResponse(json({ error: serializeError(error) }), true);
+    }
+};
+
+export const runCode: ActionTool<typeof runCodeSchema> = {
+    kind: ToolKind.Action,
+    name: "run-code",
+    description:
+        "Run arbitrary Testplane script using the current browser, useful when other tools don't provide the functionality you need. " +
+        "Inline input may be code or a function that receives browser as its only argument.",
+    schema: runCodeSchema,
+    cb: runCodeCb,
+    cli: {
+        positional: ["code"],
+        section: "Advanced",
+        usage: "[options] [code]",
+        examples: [
+            'testplane-cli run-code "await browser.getUrl()"',
+            'testplane-cli run-code "(browser) => browser.getUrl()"',
+            "testplane-cli run-code --file ./script.js",
+        ],
+    },
+};

--- a/packages/tools/test/tools/run-code.test.ts
+++ b/packages/tools/test/tools/run-code.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { WdioBrowser } from "testplane";
+import { describe, expect, it } from "vitest";
+
+import { runCode } from "../../src/tools/run-code.js";
+import { getTextContent } from "../setup.js";
+
+function parseResponse(result: { content: unknown }): { result?: unknown; error?: { message?: string } } {
+    return JSON.parse(getTextContent(result)) as { result?: unknown; error?: { message?: string } };
+}
+
+function createBrowser(): WdioBrowser {
+    return {
+        getUrl: async () => "https://example.test/page",
+        getTitle: async () => "Example",
+    } as unknown as WdioBrowser;
+}
+
+describe("tools/run-code", () => {
+    it("runs an inline expression with browser in scope", async () => {
+        const result = await runCode.cb({ code: "await browser.getUrl()" }, createBrowser());
+
+        expect(result.isError).toBeFalsy();
+        expect(parseResponse(result).result).toBe("https://example.test/page");
+    });
+
+    it("automatically invokes function input with browser", async () => {
+        const result = await runCode.cb({ code: "(b) => b.getTitle()" }, createBrowser());
+
+        expect(result.isError).toBeFalsy();
+        expect(parseResponse(result).result).toBe("Example");
+    });
+
+    it("runs statement code with explicit return", async () => {
+        const result = await runCode.cb(
+            { code: 'const url = await browser.getUrl(); return url.replace("/page", "/done");' },
+            createBrowser(),
+        );
+
+        expect(result.isError).toBeFalsy();
+        expect(parseResponse(result).result).toBe("https://example.test/done");
+    });
+
+    it("loads code from a relative file path", async () => {
+        const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "testplane-run-code-"));
+
+        try {
+            await fs.writeFile(path.join(tmpDir, "script.js"), "await browser.getUrl();", "utf8");
+
+            const result = await runCode.cb({ file: path.join(tmpDir, "script.js") }, createBrowser());
+
+            expect(result.isError).toBeFalsy();
+            expect(parseResponse(result).result).toBe("https://example.test/page");
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it("prints thrown errors as json", async () => {
+        const result = await runCode.cb({ code: 'throw new Error("boom")' }, createBrowser());
+
+        expect(result.isError).toBe(true);
+        expect(parseResponse(result).error?.message).toBe("boom");
+    });
+});


### PR DESCRIPTION
### What's done?

Implemented a run-code tool, that allows users and agents to execute arbitrary Testplane code.

Help output:

```
Usage: testplane-cli run-code [options] [code]

Run arbitrary Testplane script using the current browser, useful when other tools don't provide the functionality you need. Inline input may be code or a function that receives browser as its only argument.

Arguments:
  code            JavaScript code to run. It may be an expression like "await browser.getUrl()" or a function like "(browser) => browser.getUrl()".

Options:
  --file <value>  Path to a JavaScript file to run instead of inline code
  -h, --help      display help for command

Examples:
  testplane-cli run-code "await browser.getUrl()"
  testplane-cli run-code "(browser) => browser.getUrl()"
  testplane-cli run-code --file ./script.js
```