### PR TITLE
feat: implement time-travel-export-html tool

### DIFF
--- a/packages/mcp/test/server.e2e.test.ts
+++ b/packages/mcp/test/server.e2e.test.ts
@@ -26,6 +26,7 @@ const EXPECTED_TOOL_NAMES = [
     "test-results",
     "inspect-result",
     "time-travel-snapshot",
+    "time-travel-export-html",
     // session tools
     "launch",
     "attach",

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -20,7 +20,7 @@ import { runCode } from "./tools/run-code.js";
 import { saveState, restoreState } from "./tools/browser-state.js";
 import { inspectResult } from "./tools/inspect-result/index.js";
 import { testResults } from "./tools/test-results/index.js";
-import { timeTravelSnapshot } from "./tools/time-travel-snapshot/index.js";
+import { timeTravelExportHtml, timeTravelSnapshot } from "./tools/time-travel-snapshot/index.js";
 
 // This function just ensures that every item on a type level is a Tool<something>. AFAIK the only way to do this.
 const typeCheckedTools = <const T extends readonly unknown[]>(
@@ -51,6 +51,7 @@ export const tools = typeCheckedTools([
     testResults,
     inspectResult,
     timeTravelSnapshot,
+    timeTravelExportHtml,
 ]);
 
 export { launchBrowserWithOptions, ToolKind };

--- a/packages/tools/src/tools/time-travel-snapshot/export-html.ts
+++ b/packages/tools/src/tools/time-travel-snapshot/export-html.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { z } from "zod";
+import { createErrorResponse, createSimpleResponse } from "../../responses/index.js";
+import { StandaloneTool, ToolKind } from "../../types.js";
+import { formatFileSize, formatTimestamp } from "../../utils/formatters.js";
+import { loadTimeTravelArchive, resolveTargetTime, type TimeTravelArchive } from "./rrweb-snapshots.js";
+import { formatReportTestSteps, formatSelectedTime, formatSourceInfo } from "./formatters.js";
+import { getSnapshotInput, withRenderedTimeTravelFrame } from "./rendered-frame.js";
+import { timeTravelSelectionSchema, validateTimeTravelSelection } from "./schema.js";
+import type { SelectedSnapshotTime, SnapshotInputSelection } from "./types.js";
+
+export const timeTravelExportHtmlSchema = {
+    ...timeTravelSelectionSchema,
+    filePath: z
+        .string()
+        .min(1)
+        .transform(value => value.trim())
+        .optional()
+        .describe("Path to save the exported HTML file. Defaults to os.tmpdir()/.testplane/time-travel-snapshots"),
+};
+
+export const timeTravelExportHtmlObjectSchema = z
+    .object(timeTravelExportHtmlSchema)
+    .superRefine(validateTimeTravelSelection);
+
+export type TimeTravelExportHtmlArgs = z.output<typeof timeTravelExportHtmlObjectSchema>;
+
+interface SavedHtmlFile {
+    filePath: string;
+    fileSize: number;
+}
+
+async function saveHtmlFile(pageSource: string, filePath?: string): Promise<SavedHtmlFile> {
+    const timestamp = formatTimestamp();
+    const resolvedFilePath =
+        filePath ?? path.join(os.tmpdir(), ".testplane", "time-travel-snapshots", `${timestamp}-${randomUUID()}.html`);
+    const html = pageSource.trimStart().toLowerCase().startsWith("<!doctype")
+        ? pageSource
+        : `<!doctype html>\n${pageSource}`;
+
+    await fs.mkdir(path.dirname(resolvedFilePath), { recursive: true });
+    await fs.writeFile(resolvedFilePath, html, "utf8");
+
+    const fileStats = await fs.stat(resolvedFilePath);
+
+    return {
+        filePath: resolvedFilePath,
+        fileSize: fileStats.size,
+    };
+}
+
+function formatResponse(
+    args: TimeTravelExportHtmlArgs,
+    input: SnapshotInputSelection,
+    archive: TimeTravelArchive,
+    selectedTime: SelectedSnapshotTime,
+    saved: SavedHtmlFile,
+): string {
+    const sections = [
+        "Time travel HTML exported",
+        "## Source",
+        formatSourceInfo(args, input, archive),
+        "## Selected Time",
+        formatSelectedTime(selectedTime),
+    ];
+
+    if (input.result) {
+        const testSteps = formatReportTestSteps(input.result, archive.metadata.startTime);
+        if (testSteps) {
+            sections.push("## Test Steps", testSteps);
+        }
+    }
+
+    sections.push(
+        "## HTML File",
+        [
+            `Saved to: ${saved.filePath}`,
+            `Size: ${formatFileSize(saved.fileSize)}`,
+            "Contains rrweb-reconstructed HTML plus captured inline CSS. External assets may still point to their original URLs.",
+        ].join("\n"),
+    );
+
+    return sections.join("\n\n");
+}
+
+const timeTravelExportHtmlCb: StandaloneTool<typeof timeTravelExportHtmlSchema>["cb"] = async rawArgs => {
+    try {
+        const args = timeTravelExportHtmlObjectSchema.parse(rawArgs);
+        const input = await getSnapshotInput(args);
+        const archive = await loadTimeTravelArchive(input.source);
+        const selectedTime = resolveTargetTime(archive.metadata, {
+            time: args.time,
+            defaultAbsoluteTime: input.defaultTime?.absoluteTime,
+            defaultReason: input.defaultTime?.reason,
+        });
+        const pageSource = await withRenderedTimeTravelFrame(archive, selectedTime, browser => browser.getPageSource());
+        const saved = await saveHtmlFile(pageSource, args.filePath);
+
+        return createSimpleResponse(formatResponse(args, input, archive, selectedTime, saved));
+    } catch (error) {
+        console.error("Error exporting time travel HTML:", error);
+
+        return createErrorResponse("Error exporting time travel HTML", error instanceof Error ? error : undefined);
+    }
+};
+
+export const timeTravelExportHtml: StandaloneTool<typeof timeTravelExportHtmlSchema> = {
+    kind: ToolKind.Standalone,
+    name: "time-travel-export-html",
+    description:
+        "Export a Testplane Time Travel rrweb snapshot at a selected time as a browser-openable HTML file with captured inline styles",
+    schema: timeTravelExportHtmlSchema,
+    cb: timeTravelExportHtmlCb,
+    cli: {
+        section: "Reports",
+        examples: [
+            'testplane-cli time-travel-export-html /path/to/html-report --name "checkout submits order" --browser chrome',
+            'testplane-cli time-travel-export-html /path/to/html-report --name "checkout submits order" --browser chrome --time 250',
+            'testplane-cli time-travel-export-html /path/to/html-report --name "checkout submits order" --browser chrome --time 250 --file-path /tmp/snapshot.html',
+            "testplane-cli time-travel-export-html --snapshot-file /path/to/snapshot.zip --time 100",
+        ],
+        positional: ["report"],
+    },
+};

--- a/packages/tools/src/tools/time-travel-snapshot/export-html.ts
+++ b/packages/tools/src/tools/time-travel-snapshot/export-html.ts
@@ -7,7 +7,7 @@ import { createErrorResponse, createSimpleResponse } from "../../responses/index
 import { StandaloneTool, ToolKind } from "../../types.js";
 import { formatFileSize, formatTimestamp } from "../../utils/formatters.js";
 import { loadTimeTravelArchive, resolveTargetTime, type TimeTravelArchive } from "./rrweb-snapshots.js";
-import { formatReportTestSteps, formatSelectedTime, formatSourceInfo } from "./formatters.js";
+import { formatBrowserWindow, formatReportTestSteps, formatSelectedTime, formatSourceInfo } from "./formatters.js";
 import { getSnapshotInput, withRenderedTimeTravelFrame } from "./rendered-frame.js";
 import { timeTravelSelectionSchema, validateTimeTravelSelection } from "./schema.js";
 import type { SelectedSnapshotTime, SnapshotInputSelection } from "./types.js";
@@ -65,6 +65,8 @@ function formatResponse(
         formatSourceInfo(args, input, archive),
         "## Selected Time",
         formatSelectedTime(selectedTime),
+        "## Browser Window",
+        formatBrowserWindow(archive, selectedTime),
     ];
 
     if (input.result) {

--- a/packages/tools/src/tools/time-travel-snapshot/formatters.ts
+++ b/packages/tools/src/tools/time-travel-snapshot/formatters.ts
@@ -1,5 +1,5 @@
 import { ReporterTestResult } from "html-reporter/experimental/sdk";
-import { TimeTravelArchive } from "./rrweb-snapshots.js";
+import { resolveViewportSizeAt, type TimeTravelArchive, type TimeTravelViewportSize } from "./rrweb-snapshots.js";
 import type { TimeTravelSnapshotArgs } from "./schema.js";
 import { ReporterTestStep, SelectedSnapshotTime, SnapshotInputSelection } from "./types.js";
 import { formatTimestamp } from "../../utils/formatters.js";
@@ -107,6 +107,23 @@ export function formatSourceInfo(
     return lines.join("\n");
 }
 
+function formatViewportSource(viewport: TimeTravelViewportSize): string {
+    const offset = formatOffset(Math.round(viewport.offsetMs));
+
+    return viewport.source === "resize"
+        ? `Source: rrweb viewport resize event at ${offset}`
+        : `Source: initial rrweb meta event at ${offset}`;
+}
+
+export function formatBrowserWindow(archive: TimeTravelArchive, selectedTime: SelectedSnapshotTime): string {
+    const viewport = resolveViewportSizeAt(archive, selectedTime);
+    if (!viewport) {
+        return "Viewport size: unknown";
+    }
+
+    return [`Viewport size: ${viewport.width}x${viewport.height}`, formatViewportSource(viewport)].join("\n");
+}
+
 export function formatResponse(
     args: TimeTravelSnapshotArgs,
     input: SnapshotInputSelection,
@@ -121,6 +138,8 @@ export function formatResponse(
         formatSourceInfo(args, input, archive),
         "## Selected Time",
         formatSelectedTime(selectedTime),
+        "## Browser Window",
+        formatBrowserWindow(archive, selectedTime),
     ];
 
     if (diffFromTime) {

--- a/packages/tools/src/tools/time-travel-snapshot/formatters.ts
+++ b/packages/tools/src/tools/time-travel-snapshot/formatters.ts
@@ -1,8 +1,12 @@
 import { ReporterTestResult } from "html-reporter/experimental/sdk";
 import { TimeTravelArchive } from "./rrweb-snapshots.js";
-import { TimeTravelSnapshotArgs } from "./schema.js";
+import type { TimeTravelSnapshotArgs } from "./schema.js";
 import { ReporterTestStep, SelectedSnapshotTime, SnapshotInputSelection } from "./types.js";
 import { formatTimestamp } from "../../utils/formatters.js";
+
+interface TimeTravelSourceArgs {
+    report?: string;
+}
 
 function formatOffset(offsetMs: number): string {
     return offsetMs >= 0 ? `+${offsetMs}ms` : `${offsetMs}ms`;
@@ -61,7 +65,7 @@ export function formatReportTestSteps(result: ReporterTestResult, snapshotStartT
     return lines.join("\n");
 }
 
-function formatSelectedTime(selection: SelectedSnapshotTime): string {
+export function formatSelectedTime(selection: SelectedSnapshotTime): string {
     const lines = [
         `Reason: ${selection.reason}`,
         `Absolute timestamp: ${selection.absoluteTime} (${formatTimestamp(selection.absoluteTime)})`,
@@ -79,8 +83,8 @@ function formatSelectedTime(selection: SelectedSnapshotTime): string {
     return lines.join("\n");
 }
 
-function formatSourceInfo(
-    args: TimeTravelSnapshotArgs,
+export function formatSourceInfo(
+    args: TimeTravelSourceArgs,
     input: SnapshotInputSelection,
     archive: TimeTravelArchive,
 ): string {

--- a/packages/tools/src/tools/time-travel-snapshot/index.ts
+++ b/packages/tools/src/tools/time-travel-snapshot/index.ts
@@ -1,5 +1,3 @@
-import { readResultsFromReport } from "html-reporter/experimental/sdk";
-import type { WdioBrowser } from "testplane";
 import { createErrorResponse, createSimpleResponse } from "../../responses/index.js";
 import {
     type CaptureSnapshotOptions,
@@ -8,21 +6,14 @@ import {
     convertSnapshotToResponse,
 } from "../../responses/browser-helpers.js";
 import { StandaloneTool, ToolKind } from "../../types.js";
-import { downloadReportIfNeeded } from "../../utils/html-report.js";
-import { launchBrowserWithOptions } from "../launch-browser.js";
-import { loadTimeTravelArchive, type TimeTravelArchive, resolveTargetTime } from "./rrweb-snapshots.js";
-import {
-    findReportTestResult,
-    getReportDefaultTime,
-    getSnapshotAttachment,
-    resolveSnapshotAttachmentSource,
-} from "./report.js";
-import { startTimeTravelRenderServer, type TimeTravelRenderServer } from "./render-server.js";
+import { loadTimeTravelArchive, resolveTargetTime, type TimeTravelArchive } from "./rrweb-snapshots.js";
+import { getSnapshotInput, withRenderedTimeTravelFrame } from "./rendered-frame.js";
 import { timeTravelSnapshotObjectSchema, timeTravelSnapshotSchema, type TimeTravelSnapshotArgs } from "./schema.js";
 import { diffPageSnapshots } from "./snapshot-diff.js";
-import { SelectedSnapshotTime, SnapshotInputSelection } from "./types.js";
+import { SelectedSnapshotTime } from "./types.js";
 import { formatResponse } from "./formatters.js";
 
+export { timeTravelExportHtml, timeTravelExportHtmlObjectSchema, timeTravelExportHtmlSchema } from "./export-html.js";
 export { timeTravelSnapshotObjectSchema, timeTravelSnapshotSchema } from "./schema.js";
 export { loadTimeTravelArchive as loadRrwebSnapshotArchive, resolveTargetTime } from "./rrweb-snapshots.js";
 export {
@@ -32,8 +23,6 @@ export {
     resolveSnapshotAttachmentSource,
 } from "./report.js";
 export { diffPageSnapshots } from "./snapshot-diff.js";
-
-const RENDER_TIMEOUT_MS = 15_000;
 
 function getSnapshotOptions(args: TimeTravelSnapshotArgs): CaptureSnapshotOptions {
     return {
@@ -46,120 +35,19 @@ function getSnapshotOptions(args: TimeTravelSnapshotArgs): CaptureSnapshotOption
     };
 }
 
-async function getSnapshotInput(args: TimeTravelSnapshotArgs): Promise<SnapshotInputSelection> {
-    if (args.snapshotFile) {
-        return {
-            mode: "direct",
-            source: args.snapshotFile,
-        };
-    }
-
-    const reportPath = await downloadReportIfNeeded(args.report!);
-    const results = await readResultsFromReport(reportPath);
-    const result = findReportTestResult(results, {
-        name: args.name!,
-        browser: args.browser!,
-        attempt: args.attempt,
-    });
-    const attachment = getSnapshotAttachment(result);
-    const source = await resolveSnapshotAttachmentSource(args.report!, reportPath, attachment.path);
-
-    return {
-        mode: "report",
-        source,
-        result,
-        defaultTime: getReportDefaultTime(result),
-    };
-}
-
-function getWindowSize(archive: TimeTravelArchive): { width: number; height: number } {
-    return {
-        width: Math.min(Math.max(Math.ceil(archive.metadata.width ?? 1280), 800), 1920),
-        height: Math.min(Math.max(Math.ceil(archive.metadata.height ?? 720), 600), 1080),
-    };
-}
-
-async function waitForRender(browser: WdioBrowser): Promise<void> {
-    let renderError: string | undefined;
-
-    await browser.waitUntil(
-        async () => {
-            const status = (await browser.execute(() => {
-                const root = document.documentElement;
-
-                return {
-                    ready: root.dataset.timeTravelReady === "true",
-                    error: root.dataset.timeTravelError,
-                };
-            })) as { ready: boolean; error?: string };
-
-            renderError = status.error;
-
-            return status.ready || Boolean(status.error);
-        },
-        {
-            timeout: RENDER_TIMEOUT_MS,
-            interval: 100,
-            timeoutMsg: `Time travel snapshot renderer did not become ready within ${RENDER_TIMEOUT_MS}ms.`,
-        },
-    );
-
-    if (renderError) {
-        throw new Error(`Time travel snapshot renderer failed: ${renderError}`);
-    }
-}
-
 async function captureRenderedSnapshot(
     archive: TimeTravelArchive,
     selectedTime: SelectedSnapshotTime,
     snapshotOptions: CaptureSnapshotOptions,
 ): Promise<PageSnapshotResult> {
-    let server: TimeTravelRenderServer | null = null;
-    let browser: WdioBrowser | null = null;
-
-    try {
-        server = await startTimeTravelRenderServer(archive.events, selectedTime.offsetMs);
-        browser = await launchBrowserWithOptions({
-            headless: true,
-            windowSize: getWindowSize(archive),
-        });
-
-        await browser.openAndWait(server.url, { ignoreNetworkErrorsPatterns: [/.*/], timeout: RENDER_TIMEOUT_MS });
-        await waitForRender(browser);
-
-        const iframe = await browser.$('iframe[data-time-travel-target="true"]');
-        await iframe.waitForExist({ timeout: 5_000 });
-        await browser.switchFrame(iframe);
-
+    return withRenderedTimeTravelFrame(archive, selectedTime, async browser => {
         const snapshot = await getPageSnapshot(browser, snapshotOptions);
         if (!snapshot) {
             throw new Error("Failed to capture DOM snapshot from rrweb iframe.");
         }
 
         return snapshot;
-    } finally {
-        if (browser) {
-            try {
-                await browser.switchFrame(null);
-            } catch {
-                // The browser may already be closed or not inside a frame.
-            }
-
-            try {
-                await browser.deleteSession();
-            } catch (error) {
-                console.error("Error closing time travel snapshot browser:", error);
-            }
-        }
-
-        if (server) {
-            try {
-                await server.close();
-            } catch (error) {
-                console.error("Error closing time travel snapshot render server:", error);
-            }
-        }
-    }
+    });
 }
 
 const timeTravelSnapshotCb: StandaloneTool<typeof timeTravelSnapshotSchema>["cb"] = async rawArgs => {

--- a/packages/tools/src/tools/time-travel-snapshot/index.ts
+++ b/packages/tools/src/tools/time-travel-snapshot/index.ts
@@ -15,7 +15,11 @@ import { formatResponse } from "./formatters.js";
 
 export { timeTravelExportHtml, timeTravelExportHtmlObjectSchema, timeTravelExportHtmlSchema } from "./export-html.js";
 export { timeTravelSnapshotObjectSchema, timeTravelSnapshotSchema } from "./schema.js";
-export { loadTimeTravelArchive as loadRrwebSnapshotArchive, resolveTargetTime } from "./rrweb-snapshots.js";
+export {
+    loadTimeTravelArchive as loadRrwebSnapshotArchive,
+    resolveTargetTime,
+    resolveViewportSizeAt,
+} from "./rrweb-snapshots.js";
 export {
     findReportTestResult,
     getReportDefaultTime,

--- a/packages/tools/src/tools/time-travel-snapshot/rendered-frame.ts
+++ b/packages/tools/src/tools/time-travel-snapshot/rendered-frame.ts
@@ -2,7 +2,7 @@ import { readResultsFromReport } from "html-reporter/experimental/sdk";
 import type { WdioBrowser } from "testplane";
 import { downloadReportIfNeeded } from "../../utils/html-report.js";
 import { launchBrowserWithOptions } from "../launch-browser.js";
-import type { TimeTravelArchive } from "./rrweb-snapshots.js";
+import { resolveViewportSizeAt, type TimeTravelArchive } from "./rrweb-snapshots.js";
 import {
     findReportTestResult,
     getReportDefaultTime,
@@ -48,10 +48,15 @@ export async function getSnapshotInput(args: TimeTravelInputArgs): Promise<Snaps
     };
 }
 
-function getWindowSize(archive: TimeTravelArchive): { width: number; height: number } {
+function getWindowSize(
+    archive: TimeTravelArchive,
+    selectedTime: SelectedSnapshotTime,
+): { width: number; height: number } {
+    const viewport = resolveViewportSizeAt(archive, selectedTime);
+
     return {
-        width: Math.min(Math.max(Math.ceil(archive.metadata.width ?? 1280), 800), 1920),
-        height: Math.min(Math.max(Math.ceil(archive.metadata.height ?? 720), 600), 1080),
+        width: Math.min(Math.max(Math.ceil(viewport?.width ?? archive.metadata.width ?? 1280), 800), 1920),
+        height: Math.min(Math.max(Math.ceil(viewport?.height ?? archive.metadata.height ?? 720), 600), 1080),
     };
 }
 
@@ -97,7 +102,7 @@ export async function withRenderedTimeTravelFrame<T>(
         server = await startTimeTravelRenderServer(archive.events, selectedTime.offsetMs);
         browser = await launchBrowserWithOptions({
             headless: true,
-            windowSize: getWindowSize(archive),
+            windowSize: getWindowSize(archive, selectedTime),
         });
 
         await browser.openAndWait(server.url, { ignoreNetworkErrorsPatterns: [/.*/], timeout: RENDER_TIMEOUT_MS });

--- a/packages/tools/src/tools/time-travel-snapshot/rendered-frame.ts
+++ b/packages/tools/src/tools/time-travel-snapshot/rendered-frame.ts
@@ -1,0 +1,134 @@
+import { readResultsFromReport } from "html-reporter/experimental/sdk";
+import type { WdioBrowser } from "testplane";
+import { downloadReportIfNeeded } from "../../utils/html-report.js";
+import { launchBrowserWithOptions } from "../launch-browser.js";
+import type { TimeTravelArchive } from "./rrweb-snapshots.js";
+import {
+    findReportTestResult,
+    getReportDefaultTime,
+    getSnapshotAttachment,
+    resolveSnapshotAttachmentSource,
+} from "./report.js";
+import { startTimeTravelRenderServer, type TimeTravelRenderServer } from "./render-server.js";
+import type { SnapshotInputSelection, SelectedSnapshotTime } from "./types.js";
+
+const RENDER_TIMEOUT_MS = 15_000;
+
+interface TimeTravelInputArgs {
+    report?: string;
+    name?: string;
+    browser?: string;
+    attempt?: number;
+    snapshotFile?: string;
+}
+
+export async function getSnapshotInput(args: TimeTravelInputArgs): Promise<SnapshotInputSelection> {
+    if (args.snapshotFile) {
+        return {
+            mode: "direct",
+            source: args.snapshotFile,
+        };
+    }
+
+    const reportPath = await downloadReportIfNeeded(args.report!);
+    const results = await readResultsFromReport(reportPath);
+    const result = findReportTestResult(results, {
+        name: args.name!,
+        browser: args.browser!,
+        attempt: args.attempt,
+    });
+    const attachment = getSnapshotAttachment(result);
+    const source = await resolveSnapshotAttachmentSource(args.report!, reportPath, attachment.path);
+
+    return {
+        mode: "report",
+        source,
+        result,
+        defaultTime: getReportDefaultTime(result),
+    };
+}
+
+function getWindowSize(archive: TimeTravelArchive): { width: number; height: number } {
+    return {
+        width: Math.min(Math.max(Math.ceil(archive.metadata.width ?? 1280), 800), 1920),
+        height: Math.min(Math.max(Math.ceil(archive.metadata.height ?? 720), 600), 1080),
+    };
+}
+
+async function waitForRender(browser: WdioBrowser): Promise<void> {
+    let renderError: string | undefined;
+
+    await browser.waitUntil(
+        async () => {
+            const status = (await browser.execute(() => {
+                const root = document.documentElement;
+
+                return {
+                    ready: root.dataset.timeTravelReady === "true",
+                    error: root.dataset.timeTravelError,
+                };
+            })) as { ready: boolean; error?: string };
+
+            renderError = status.error;
+
+            return status.ready || Boolean(status.error);
+        },
+        {
+            timeout: RENDER_TIMEOUT_MS,
+            interval: 100,
+            timeoutMsg: `Time travel snapshot renderer did not become ready within ${RENDER_TIMEOUT_MS}ms.`,
+        },
+    );
+
+    if (renderError) {
+        throw new Error(`Time travel snapshot renderer failed: ${renderError}`);
+    }
+}
+
+export async function withRenderedTimeTravelFrame<T>(
+    archive: TimeTravelArchive,
+    selectedTime: SelectedSnapshotTime,
+    cb: (browser: WdioBrowser) => Promise<T>,
+): Promise<T> {
+    let server: TimeTravelRenderServer | null = null;
+    let browser: WdioBrowser | null = null;
+
+    try {
+        server = await startTimeTravelRenderServer(archive.events, selectedTime.offsetMs);
+        browser = await launchBrowserWithOptions({
+            headless: true,
+            windowSize: getWindowSize(archive),
+        });
+
+        await browser.openAndWait(server.url, { ignoreNetworkErrorsPatterns: [/.*/], timeout: RENDER_TIMEOUT_MS });
+        await waitForRender(browser);
+
+        const iframe = await browser.$('iframe[data-time-travel-target="true"]');
+        await iframe.waitForExist({ timeout: 5_000 });
+        await browser.switchFrame(iframe);
+
+        return await cb(browser);
+    } finally {
+        if (browser) {
+            try {
+                await browser.switchFrame(null);
+            } catch {
+                // The browser may already be closed or not inside a frame.
+            }
+
+            try {
+                await browser.deleteSession();
+            } catch (error) {
+                console.error("Error closing time travel snapshot browser:", error);
+            }
+        }
+
+        if (server) {
+            try {
+                await server.close();
+            } catch (error) {
+                console.error("Error closing time travel snapshot render server:", error);
+            }
+        }
+    }
+}

--- a/packages/tools/src/tools/time-travel-snapshot/rrweb-snapshots.ts
+++ b/packages/tools/src/tools/time-travel-snapshot/rrweb-snapshots.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { unzipSync } from "fflate";
-import type { eventWithTime as RrwebEvent } from "@rrweb/types";
+import { type eventWithTime as RrwebEvent, IncrementalSource } from "@rrweb/types";
 import { SelectedSnapshotTime } from "./types.js";
 
 export type NumberedRrwebEvent = RrwebEvent & { seqNo: number };
@@ -26,7 +26,17 @@ export interface ResolveTargetTimeOptions {
     defaultReason?: string;
 }
 
+export interface TimeTravelViewportSize {
+    width: number;
+    height: number;
+    source: "meta" | "resize";
+    timestamp: number;
+    offsetMs: number;
+}
+
 const SNAPSHOTS_FILE_NAME = "snapshots.json";
+const RRWEB_INCREMENTAL_SNAPSHOT_EVENT = 3;
+const RRWEB_META_EVENT = 4;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -69,13 +79,67 @@ async function readTimeTravelZip(source: string): Promise<Uint8Array> {
     return new Uint8Array(await readFile(sourceToLocalPath(source)));
 }
 
+function getViewportSizeData(data: unknown): Pick<TimeTravelViewportSize, "width" | "height"> | null {
+    if (!isRecord(data) || typeof data.width !== "number" || typeof data.height !== "number") {
+        return null;
+    }
+
+    return {
+        width: data.width,
+        height: data.height,
+    };
+}
+
 function getViewportMetadata(events: readonly NumberedRrwebEvent[]): Pick<RrwebSnapshotMetadata, "width" | "height"> {
-    const metaEvent = events.find(event => event.type === 4 && isRecord(event.data));
-    const data = isRecord(metaEvent?.data) ? metaEvent.data : undefined;
-    const width = typeof data?.width === "number" ? data.width : undefined;
-    const height = typeof data?.height === "number" ? data.height : undefined;
+    const metaEvent = events.find(event => event.type === RRWEB_META_EVENT);
+    const size = getViewportSizeData(metaEvent?.data);
+    const width = size?.width;
+    const height = size?.height;
 
     return { width, height };
+}
+
+export function resolveViewportSizeAt(
+    archive: TimeTravelArchive,
+    selectedTime: SelectedSnapshotTime,
+): TimeTravelViewportSize | null {
+    let viewport: TimeTravelViewportSize | null = null;
+
+    for (const event of archive.events) {
+        if (event.type === RRWEB_META_EVENT && viewport === null) {
+            const size = getViewportSizeData(event.data);
+            if (size) {
+                viewport = {
+                    ...size,
+                    source: "meta",
+                    timestamp: event.timestamp,
+                    offsetMs: event.timestamp - archive.metadata.startTime,
+                };
+            }
+            continue;
+        }
+
+        if (event.timestamp > selectedTime.absoluteTime || event.type !== RRWEB_INCREMENTAL_SNAPSHOT_EVENT) {
+            continue;
+        }
+
+        const data = isRecord(event.data) ? event.data : undefined;
+        if (data?.source !== IncrementalSource.ViewportResize) {
+            continue;
+        }
+
+        const size = getViewportSizeData(data);
+        if (size) {
+            viewport = {
+                ...size,
+                source: "resize",
+                timestamp: event.timestamp,
+                offsetMs: event.timestamp - archive.metadata.startTime,
+            };
+        }
+    }
+
+    return viewport;
 }
 
 export async function loadTimeTravelArchive(source: string): Promise<TimeTravelArchive> {

--- a/packages/tools/src/tools/time-travel-snapshot/schema.ts
+++ b/packages/tools/src/tools/time-travel-snapshot/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const timeTravelSnapshotSchema = {
+export const timeTravelSelectionSchema = {
     report: z
         .string()
         .min(1)
@@ -39,26 +39,18 @@ export const timeTravelSnapshotSchema = {
         .describe(
             "Time to inspect in milliseconds. Values within snapshot duration are offsets from the first rrweb event; larger values are absolute timestamps",
         ),
-    diffFrom: z
-        .number()
-        .finite()
-        .min(0, "--diff-from must be >= 0")
-        .optional()
-        .describe(
-            "When set, return only current DOM nodes that changed between this time and the requested time. Uses the same offset/timestamp rules as time",
-        ),
-    includeTags: z.array(z.string()).optional().describe("HTML tags to include in the snapshot besides defaults"),
-    includeAttrs: z
-        .array(z.string())
-        .optional()
-        .describe("HTML attributes to include in the snapshot besides defaults"),
-    excludeTags: z.array(z.string()).optional().describe("HTML tags to exclude from the snapshot"),
-    excludeAttrs: z.array(z.string()).optional().describe("HTML attributes to exclude from the snapshot"),
-    truncateText: z.boolean().optional().describe("Whether to truncate long text content (default: true)"),
-    maxTextLength: z.number().positive().optional().describe("Maximum length of text content before truncation"),
 };
 
-export const timeTravelSnapshotObjectSchema = z.object(timeTravelSnapshotSchema).superRefine((args, ctx) => {
+export function validateTimeTravelSelection(
+    args: {
+        report?: string;
+        name?: string;
+        browser?: string;
+        snapshotFile?: string;
+        time?: number;
+    },
+    ctx: z.RefinementCtx,
+): void {
     const hasReportMode = args.report !== undefined || args.name !== undefined || args.browser !== undefined;
     const hasDirectMode = args.snapshotFile !== undefined;
 
@@ -88,6 +80,31 @@ export const timeTravelSnapshotObjectSchema = z.object(timeTravelSnapshotSchema)
                 'Provide either "snapshotFile" with "time" or all report mode fields: "report", "name", and "browser".',
         });
     }
-});
+}
+
+export const timeTravelSnapshotSchema = {
+    ...timeTravelSelectionSchema,
+    diffFrom: z
+        .number()
+        .finite()
+        .min(0, "--diff-from must be >= 0")
+        .optional()
+        .describe(
+            "When set, return only current DOM nodes that changed between this time and the requested time. Uses the same offset/timestamp rules as time",
+        ),
+    includeTags: z.array(z.string()).optional().describe("HTML tags to include in the snapshot besides defaults"),
+    includeAttrs: z
+        .array(z.string())
+        .optional()
+        .describe("HTML attributes to include in the snapshot besides defaults"),
+    excludeTags: z.array(z.string()).optional().describe("HTML tags to exclude from the snapshot"),
+    excludeAttrs: z.array(z.string()).optional().describe("HTML attributes to exclude from the snapshot"),
+    truncateText: z.boolean().optional().describe("Whether to truncate long text content (default: true)"),
+    maxTextLength: z.number().positive().optional().describe("Maximum length of text content before truncation"),
+};
+
+export const timeTravelSnapshotObjectSchema = z
+    .object(timeTravelSnapshotSchema)
+    .superRefine(validateTimeTravelSelection);
 
 export type TimeTravelSnapshotArgs = z.output<typeof timeTravelSnapshotObjectSchema>;

--- a/packages/tools/test/tools/time-travel-snapshot.test.ts
+++ b/packages/tools/test/tools/time-travel-snapshot.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readResultsFromReport } from "html-reporter/experimental/sdk";
@@ -12,6 +14,8 @@ import {
     loadRrwebSnapshotArchive,
     resolveSnapshotAttachmentSource,
     resolveTargetTime,
+    timeTravelExportHtml,
+    timeTravelExportHtmlObjectSchema,
     timeTravelSnapshot,
     timeTravelSnapshotObjectSchema,
 } from "../../src/tools/time-travel-snapshot/index.js";
@@ -22,9 +26,21 @@ const SAMPLE_REPORT = fileURLToPath(new URL("../fixtures/sample-html-report", im
 const SAMPLE_SNAPSHOT = path.join(SAMPLE_REPORT, "snapshots/2570334/chrome_1778522878896_1.zip");
 
 type TimeTravelSnapshotInput = z.input<typeof timeTravelSnapshotObjectSchema>;
+type TimeTravelExportHtmlInput = z.input<typeof timeTravelExportHtmlObjectSchema>;
 
 function parseArgs(args: TimeTravelSnapshotInput) {
     return timeTravelSnapshotObjectSchema.parse(args);
+}
+
+function parseExportHtmlArgs(args: TimeTravelExportHtmlInput) {
+    return timeTravelExportHtmlObjectSchema.parse(args);
+}
+
+function extractSavedHtmlPath(responseText: string): string {
+    const match = responseText.match(/Saved to: (.+\.html)/);
+    if (!match) throw new Error(`No saved HTML path found in response:\n${responseText}`);
+
+    return match[1];
 }
 
 describe("tools/time-travel-snapshot", () => {
@@ -61,6 +77,19 @@ describe("tools/time-travel-snapshot", () => {
                 .success,
         ).toBe(false);
         expect(timeTravelSnapshotObjectSchema.safeParse({ report: SAMPLE_REPORT, name: "test" }).success).toBe(false);
+
+        expect(timeTravelExportHtmlObjectSchema.safeParse({ snapshotFile: SAMPLE_SNAPSHOT, time: 134 }).success).toBe(
+            true,
+        );
+        expect(
+            timeTravelExportHtmlObjectSchema.safeParse({
+                report: SAMPLE_REPORT,
+                name: "success describe successfully passed test",
+                browser: "chrome",
+                filePath: path.join(os.tmpdir(), "snapshot.html"),
+            }).success,
+        ).toBe(true);
+        expect(timeTravelExportHtmlObjectSchema.safeParse({ snapshotFile: SAMPLE_SNAPSHOT }).success).toBe(false);
     });
 
     it("loads rrweb snapshot archives and resolves smart time values", async () => {
@@ -351,5 +380,57 @@ describe("tools/time-travel-snapshot", () => {
         expect(text).toContain("Reason: provided offset 134ms from first rrweb event");
         expect(text).toContain("Some header");
         expect(text).toContain("Lorem ipsum dolor sit amet");
+    }, 30_000);
+
+    it("exports the rrweb iframe HTML to the default tmp path", async () => {
+        const result = await timeTravelExportHtml.cb(
+            parseExportHtmlArgs({
+                snapshotFile: SAMPLE_SNAPSHOT,
+                time: 134,
+            }),
+        );
+        const text = getTextContent(result);
+
+        expect(result.isError).toBe(false);
+        expect(text).toContain("Time travel HTML exported");
+        expect(text).toContain(".testplane/time-travel-snapshots");
+        expect(text).toContain("Contains rrweb-reconstructed HTML plus captured inline CSS");
+
+        const htmlPath = extractSavedHtmlPath(text);
+        const html = await fs.readFile(htmlPath, "utf8");
+
+        expect(html).toContain("<!doctype html>");
+        expect(html).toContain("Some header");
+        expect(html).toContain("Lorem ipsum dolor sit amet");
+        expect(html).toContain(".text {");
+        expect(html).not.toContain("__timeTravelReplayer");
+        expect(html).not.toContain('data-time-travel-target="true"');
+
+        await fs.unlink(htmlPath).catch(() => {});
+    }, 30_000);
+
+    it("exports the rrweb iframe HTML to a custom file path", async () => {
+        const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "testplane-time-travel-export-"));
+        const filePath = path.join(tmpDir, "nested", "snapshot.html");
+
+        try {
+            const result = await timeTravelExportHtml.cb(
+                parseExportHtmlArgs({
+                    snapshotFile: SAMPLE_SNAPSHOT,
+                    time: 134,
+                    filePath,
+                }),
+            );
+            const text = getTextContent(result);
+
+            expect(result.isError).toBe(false);
+            expect(text).toContain(`Saved to: ${filePath}`);
+
+            const html = await fs.readFile(filePath, "utf8");
+            expect(html).toContain("Some header");
+            expect(html).toContain(".text {");
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
     }, 30_000);
 });

--- a/packages/tools/test/tools/time-travel-snapshot.test.ts
+++ b/packages/tools/test/tools/time-travel-snapshot.test.ts
@@ -14,6 +14,7 @@ import {
     loadRrwebSnapshotArchive,
     resolveSnapshotAttachmentSource,
     resolveTargetTime,
+    resolveViewportSizeAt,
     timeTravelExportHtml,
     timeTravelExportHtmlObjectSchema,
     timeTravelSnapshot,
@@ -111,6 +112,13 @@ describe("tools/time-travel-snapshot", () => {
             requestedKind: "offset",
             wasClamped: false,
         });
+        expect(resolveViewportSizeAt(archive, offsetTime)).toMatchObject({
+            width: 1280,
+            height: 1024,
+            source: "meta",
+            timestamp: 1778522879037,
+            offsetMs: 134,
+        });
 
         const timestampTime = resolveTargetTime(archive.metadata, { time: 1778522879143 });
         expect(timestampTime).toMatchObject({
@@ -127,6 +135,60 @@ describe("tools/time-travel-snapshot", () => {
             requestedKind: "timestamp",
             wasClamped: true,
         });
+    });
+
+    it("resolves viewport size from the latest resize event at the selected time", () => {
+        const archive = {
+            source: "synthetic",
+            events: [
+                { type: 4, timestamp: 1010, data: { width: 800, height: 600 }, seqNo: 0 },
+                { type: 3, timestamp: 1100, data: { source: 4, width: 1024, height: 768 }, seqNo: 1 },
+                { type: 3, timestamp: 1300, data: { source: 4, width: 1200, height: 900 }, seqNo: 2 },
+            ] as never,
+            metadata: {
+                startTime: 1000,
+                endTime: 1400,
+                totalTime: 400,
+                width: 800,
+                height: 600,
+            },
+        };
+
+        expect(resolveViewportSizeAt(archive, resolveTargetTime(archive.metadata, { time: 0 }))).toMatchObject({
+            width: 800,
+            height: 600,
+            source: "meta",
+            timestamp: 1010,
+            offsetMs: 10,
+        });
+        expect(resolveViewportSizeAt(archive, resolveTargetTime(archive.metadata, { time: 150 }))).toMatchObject({
+            width: 1024,
+            height: 768,
+            source: "resize",
+            timestamp: 1100,
+            offsetMs: 100,
+        });
+        expect(resolveViewportSizeAt(archive, resolveTargetTime(archive.metadata, { time: 350 }))).toMatchObject({
+            width: 1200,
+            height: 900,
+            source: "resize",
+            timestamp: 1300,
+            offsetMs: 300,
+        });
+    });
+
+    it("returns null when no rrweb viewport size data is available", () => {
+        const archive = {
+            source: "synthetic",
+            events: [{ type: 3, timestamp: 1000, data: { source: 0 }, seqNo: 0 }] as never,
+            metadata: {
+                startTime: 1000,
+                endTime: 1000,
+                totalTime: 0,
+            },
+        };
+
+        expect(resolveViewportSizeAt(archive, resolveTargetTime(archive.metadata, { time: 0 }))).toBeNull();
     });
 
     it("selects report attempts, resolves snapshot attachments, and picks default times", async () => {
@@ -378,6 +440,9 @@ describe("tools/time-travel-snapshot", () => {
         expect(text).toContain("Time travel snapshot captured");
         expect(text).toContain("## Selected Time");
         expect(text).toContain("Reason: provided offset 134ms from first rrweb event");
+        expect(text).toContain("## Browser Window");
+        expect(text).toContain("Viewport size: 1280x1024");
+        expect(text).toContain("Source: initial rrweb meta event at +134ms");
         expect(text).toContain("Some header");
         expect(text).toContain("Lorem ipsum dolor sit amet");
     }, 30_000);
@@ -393,6 +458,8 @@ describe("tools/time-travel-snapshot", () => {
 
         expect(result.isError).toBe(false);
         expect(text).toContain("Time travel HTML exported");
+        expect(text).toContain("## Browser Window");
+        expect(text).toContain("Viewport size: 1280x1024");
         expect(text).toContain(".testplane/time-travel-snapshots");
         expect(text).toContain("Contains rrweb-reconstructed HTML plus captured inline CSS");
 


### PR DESCRIPTION
### What's done?

Implemented a tool that allows to export HTML page from a given time travel snapshot at a specific moment.

Useful to debug this page further with testplane, testplane cli or by hand in browser.

Also added viewport size to response text for time travel related commands.